### PR TITLE
fix(database): set pagination data on request body

### DIFF
--- a/src/Endpoint/DatabasesEndpoint.php
+++ b/src/Endpoint/DatabasesEndpoint.php
@@ -18,6 +18,8 @@ use Brd6\NotionSdkPhp\Resource\Pagination\AbstractPaginationResults;
 use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
 use Http\Client\Exception;
 
+use function array_merge;
+
 class DatabasesEndpoint extends AbstractEndpoint
 {
     /**
@@ -37,10 +39,14 @@ class DatabasesEndpoint extends AbstractEndpoint
         ?DatabaseRequest $databaseRequest = null,
         ?PaginationRequest $paginationRequest = null
     ): AbstractPaginationResults {
+        $body = array_merge(
+            $paginationRequest ? $paginationRequest->toArray() : [],
+            $databaseRequest ? $databaseRequest->toArray() : [],
+        );
+
         $requestParameters = (new RequestParameters())
             ->setPath("databases/$databaseId/query")
-            ->setQuery($paginationRequest ? $paginationRequest->toArray() : [])
-            ->setBody($databaseRequest ? $databaseRequest->toArray() : [])
+            ->setBody($body)
             ->setMethod('POST');
 
         $rawData = $this->getClient()->request($requestParameters);

--- a/tests/Endpoint/DatabasesEndpointTest.php
+++ b/tests/Endpoint/DatabasesEndpointTest.php
@@ -85,7 +85,11 @@ class DatabasesEndpointTest extends TestCase
     {
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
             $this->assertEquals('POST', $method);
-            $this->assertEquals(2, $options['query']['page_size']);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals(2, $body['page_size']);
 
             return new MockResponseFactory(
                 (string) file_get_contents('tests/Fixtures/client_databases_query_200.json'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Move the data sent for pagination in body part of the database request.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A request with pagination does not work because the pagination data is sent in `query` instead `body`.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Database test for pagination has been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
