### PR TITLE
fix(search): data sent in body request

### DIFF
--- a/src/Endpoint/SearchEndpoint.php
+++ b/src/Endpoint/SearchEndpoint.php
@@ -15,6 +15,8 @@ use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
 use Brd6\NotionSdkPhp\Resource\Search\SearchRequest;
 use Http\Client\Exception;
 
+use function array_merge;
+
 class SearchEndpoint extends AbstractEndpoint
 {
     /**
@@ -32,10 +34,14 @@ class SearchEndpoint extends AbstractEndpoint
         ?SearchRequest $searchRequest = null,
         ?PaginationRequest $paginationRequest = null
     ): AbstractPaginationResults {
+        $body = array_merge(
+            $searchRequest ? $searchRequest->toArray() : [],
+            $paginationRequest ? $paginationRequest->toArray() : [],
+        );
+
         $requestParameters = (new RequestParameters())
             ->setPath('search')
-            ->setQuery($paginationRequest ? $paginationRequest->toArray() : [])
-            ->setBody($searchRequest ? $searchRequest->toArray() : [])
+            ->setBody($body)
             ->setMethod('POST');
 
         $rawData = $this->getClient()->request($requestParameters);

--- a/src/Resource/Search/SearchRequest.php
+++ b/src/Resource/Search/SearchRequest.php
@@ -9,7 +9,7 @@ use Brd6\NotionSdkPhp\Resource\AbstractJsonSerializable;
 class SearchRequest extends AbstractJsonSerializable
 {
     protected array $filter = [];
-    protected array $sorts = [];
+    protected array $sort = [];
     protected ?string $query = null;
 
     public function getFilter(): array
@@ -24,14 +24,14 @@ class SearchRequest extends AbstractJsonSerializable
         return $this;
     }
 
-    public function getSorts(): array
+    public function getSort(): array
     {
-        return $this->sorts;
+        return $this->sort;
     }
 
-    public function setSorts(array $sorts): self
+    public function setSort(array $sort): self
     {
-        $this->sorts = $sorts;
+        $this->sort = $sort;
 
         return $this;
     }

--- a/tests/Endpoint/SearchEndpointTest.php
+++ b/tests/Endpoint/SearchEndpointTest.php
@@ -8,12 +8,14 @@ use Brd6\NotionSdkPhp\Client;
 use Brd6\NotionSdkPhp\ClientOptions;
 use Brd6\NotionSdkPhp\Resource\Database;
 use Brd6\NotionSdkPhp\Resource\Pagination\PageOrDatabaseResults;
+use Brd6\NotionSdkPhp\Resource\Search\SearchRequest;
 use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
 use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockResponseFactory;
 use Brd6\Test\NotionSdkPhp\TestCase;
 
 use function count;
 use function file_get_contents;
+use function json_decode;
 
 class SearchEndpointTest extends TestCase
 {
@@ -50,5 +52,51 @@ class SearchEndpointTest extends TestCase
 
         $this->assertEquals('database', $resultDatabase->getObject());
         $this->assertNotEmpty($resultDatabase->getId());
+    }
+
+    public function testSearchWithParams(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString('search', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals('page', $body['filter']['value']);
+            $this->assertEquals('last_edited_time', $body['sort']['timestamp']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_search_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $searchRequest = (new SearchRequest())
+            ->setFilter([
+                'property' => 'object',
+                'value' => 'page',
+            ])
+            ->setSort([
+                'direction' => 'descending',
+                'timestamp' => 'last_edited_time',
+            ]);
+
+        /** @var PageOrDatabaseResults $results */
+        $results = $client->search($searchRequest);
+
+        $this->assertInstanceOf(PageOrDatabaseResults::class, $results);
+
+        $this->assertEquals('page_or_database', $results->getType());
+        $this->assertEquals('list', $results->getObject());
+        $this->assertGreaterThan(0, count($results->getResults()));
+        $this->assertLessThanOrEqual(16, count($results->getResults()));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Move the data sent for pagination in body part of the search request.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A request with pagination does not work because the pagination data is sent in query instead body.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Search test for pagination has been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
