### PR TITLE
Fix wrong access to Number

### DIFF
--- a/src/Resource/Page/PropertyValue/NumberPropertyValue.php
+++ b/src/Resource/Page/PropertyValue/NumberPropertyValue.php
@@ -10,7 +10,7 @@ class NumberPropertyValue extends AbstractPropertyValue
 
     protected function initialize(): void
     {
-        $data = (array) $this->getRawData();
+        $data = $this->getRawData();
         $this->number = isset($data['number']) ? (int) $data['number'] : null;
     }
 


### PR DESCRIPTION
Fix wrong access to Number

## Description
$this->getRawData()[$this->getType()]; gets direct access to number, which is wrong as it can be !isset

## Motivation and context
I was not able to get the number value

## How has this been tested?
Simple test in my environnement

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
