### PR TITLE
fix: allow empty string in serialized data

### DIFF
--- a/src/Resource/AbstractJsonSerializable.php
+++ b/src/Resource/AbstractJsonSerializable.php
@@ -20,6 +20,7 @@ use const ARRAY_FILTER_USE_BOTH;
 abstract class AbstractJsonSerializable implements JsonSerializable
 {
     private const EXCLUDED_KEYS = ['ignoreEmptyValue', 'rawData', 'onlyKeys'];
+    private const ALLOWED_EMPTY_VALUE_KEYS = ['content'];
 
     private bool $ignoreEmptyValue = true;
     private array $onlyKeys = [];
@@ -60,7 +61,7 @@ abstract class AbstractJsonSerializable implements JsonSerializable
             return true;
         }
 
-        return $this->shouldSerializeValue($value);
+        return $this->shouldSerializeValue($key, $value);
     }
 
     private function shouldIgnoreKey(string $key): bool
@@ -76,13 +77,13 @@ abstract class AbstractJsonSerializable implements JsonSerializable
     /**
      * @param mixed $value
      */
-    private function shouldSerializeValue($value): bool
+    private function shouldSerializeValue(string $key, $value): bool
     {
-        if (!$this->ignoreEmptyValue) {
+        if (!$this->ignoreEmptyValue || in_array($key, self::ALLOWED_EMPTY_VALUE_KEYS)) {
             return true;
         }
 
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return false;
         }
 

--- a/tests/Fixtures/client_blocks_retrieve_block_empty_text_content_200.json
+++ b/tests/Fixtures/client_blocks_retrieve_block_empty_text_content_200.json
@@ -1,0 +1,39 @@
+{
+    "object": "block",
+    "id": "0c940186-ab70-4351-bb34-2d16f0635d49",
+    "created_time": "2022-03-01T18:42:00.000Z",
+    "last_edited_time": "2022-03-01T18:54:00.000Z",
+    "created_by": {
+        "object": "user",
+        "id": "1091c8fb-8b5a-4cc2-afe9-fdf0367e16d6"
+    },
+    "last_edited_by": {
+        "object": "user",
+        "id": "1091c8fb-8b5a-4cc2-afe9-fdf0367e16d6"
+    },
+    "has_children": false,
+    "archived": false,
+    "type": "paragraph",
+    "paragraph": {
+        "rich_text": [
+            {
+                "type": "text",
+                "text": {
+                    "content": "",
+                    "link": null
+                },
+                "annotations": {
+                    "bold": false,
+                    "italic": false,
+                    "strikethrough": false,
+                    "underline": false,
+                    "code": false,
+                    "color": "default"
+                },
+                "plain_text": "",
+                "href": null
+            }
+        ],
+        "color": "default"
+    }
+}

--- a/tests/Resource/BlockTest.php
+++ b/tests/Resource/BlockTest.php
@@ -242,4 +242,35 @@ class BlockTest extends TestCase
             $block->getSyncedBlock()->getSyncedFrom()->getBlockId(),
         );
     }
+
+    public function testFromRawDataWithEmptyContentInRichText(): void
+    {
+        /** @var ParagraphBlock $block */
+        $block = AbstractBlock::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_empty_text_content_200.json'),
+                true,
+            ),
+        );
+
+        /** @var Text $richText */
+        $richText = $block->getParagraph()->getRichText()[0];
+
+        $this->assertEquals('', $richText->getText()->getContent());
+        $this->assertEquals('', $richText->getPlainText());
+    }
+
+    public function testCreateEmptyContentInRichText(): void
+    {
+        $richText = Text::fromContent('');
+
+        $this->assertEquals('', $richText->getText()->getContent());
+        $this->assertEquals('', $richText->getPlainText());
+
+        $richTextData = $richText->toArray();
+
+        $this->assertArrayHasKey('text', $richTextData);
+        $this->assertArrayHasKey('content', $richTextData['text']);
+        $this->assertEquals('', $richTextData['text']['content']);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
- Allow empty string to be serialized
- Improve the readability of the method canBeSerialized

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Empty texts are not serialized, which prevents the creation of a block with empty text via the Notion API. (fix #21)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests have been added to ensure that empty texts are serialized.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
