### PR TITLE
Fix float number in property value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.2.0 - TBD
+## 1.2.1 - 2023-10-24
+
+### Added
+
+- Add missing Status property value type
+
+## 1.2.0 - 2023-10-24
 
 ### Added
 

--- a/src/Resource/Page/PropertyValue/NumberPropertyValue.php
+++ b/src/Resource/Page/PropertyValue/NumberPropertyValue.php
@@ -6,20 +6,20 @@ namespace Brd6\NotionSdkPhp\Resource\Page\PropertyValue;
 
 class NumberPropertyValue extends AbstractPropertyValue
 {
-    protected ?int $number = null;
+    protected ?float $number = null;
 
     protected function initialize(): void
     {
         $data = $this->getRawData();
-        $this->number = isset($data['number']) ? (int) $data['number'] : null;
+        $this->number = isset($data['number']) ? (float) $data['number'] : null;
     }
 
-    public function getNumber(): ?int
+    public function getNumber(): ?float
     {
         return $this->number;
     }
 
-    public function setNumber(int $number): self
+    public function setNumber(float $number): self
     {
         $this->number = $number;
 

--- a/src/Resource/Property/Value/NumberValueProperty.php
+++ b/src/Resource/Property/Value/NumberValueProperty.php
@@ -6,21 +6,21 @@ namespace Brd6\NotionSdkPhp\Resource\Property\Value;
 
 class NumberValueProperty extends AbstractValueProperty
 {
-    protected ?int $number = null;
+    protected ?float $number = null;
 
     protected function initialize(): void
     {
         $this->number = isset($this->getRawData()['number']) ?
-            (int) $this->getRawData()['number'] :
+            (float) $this->getRawData()['number'] :
             null;
     }
 
-    public function getNumber(): ?int
+    public function getNumber(): ?float
     {
         return $this->number;
     }
 
-    public function setNumber(int $number): self
+    public function setNumber(float $number): self
     {
         $this->number = $number;
 

--- a/tests/Fixtures/client_pages_retrieve_page_properties_200.json
+++ b/tests/Fixtures/client_pages_retrieve_page_properties_200.json
@@ -52,6 +52,11 @@
             "type": "number",
             "number": 42
         },
+        "My number float": {
+            "id": "%40aiB",
+            "type": "number",
+            "number": 42.42
+        },
         "formula2": {
             "id": "H%3BxC",
             "type": "formula",

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -8,6 +8,7 @@ use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
 use Brd6\NotionSdkPhp\Resource\File\Emoji;
 use Brd6\NotionSdkPhp\Resource\File\External;
 use Brd6\NotionSdkPhp\Resource\Page;
+use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\NumberPropertyValue;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -87,5 +88,29 @@ class PageTest extends TestCase
             $this->assertNotEmpty($property->getType());
             $this->assertNotEmpty($property->toArray());
         }
+    }
+
+    public function testNumberProperty(): void
+    {
+        /** @var Page $page */
+        $page = Page::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_properties_200.json'),
+                true,
+            ),
+        );
+
+        $properties = $page->getProperties();
+
+        /** @var NumberPropertyValue $myNumber */
+        $myNumber = $properties['My number'];
+
+        $this->assertInstanceOf(NumberPropertyValue::class, $myNumber);
+        $this->assertEquals(42, $myNumber->getNumber());
+
+        $myNumberFloat = $properties['My number float'];
+
+        $this->assertInstanceOf(NumberPropertyValue::class, $myNumberFloat);
+        $this->assertEquals(42.42, $myNumberFloat->getNumber());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Updated `NumberValueProperty` class to handle decimal values by changing the type from `int` to `float`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue where decimal numbers in Notion databases were incorrectly rounded down, impacting data accuracy.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in PHP 8.1, ensuring decimal numbers are now accurately handled without adverse side effects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
