### PR TITLE
feat: add support for audio block

### DIFF
--- a/src/Resource/Block/AudioBlock.php
+++ b/src/Resource/Block/AudioBlock.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Exception\InvalidFileException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedFileTypeException;
+use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
+
+class AudioBlock extends AbstractBlock
+{
+    protected ?AbstractFile $audio = null;
+
+    /**
+     * @throws InvalidFileException
+     * @throws UnsupportedFileTypeException
+     */
+    protected function initializeBlockProperty(): void
+    {
+        $data = (array) $this->getRawData()[$this->getType()];
+        $this->audio = AbstractFile::fromRawData($data);
+    }
+
+    public function getAudio(): ?AbstractFile
+    {
+        return $this->audio;
+    }
+
+    public function setAudio(?AbstractFile $audio): self
+    {
+        $this->audio = $audio;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/client_blocks_retrieve_block_audio_200.json
+++ b/tests/Fixtures/client_blocks_retrieve_block_audio_200.json
@@ -1,0 +1,30 @@
+{
+    "object": "block",
+    "id": "11589ea8-2c3c-808b-b14a-e58dad7e476f",
+    "parent": {
+        "type": "page_id",
+        "page_id": "11289ea8-2c3c-8142-a654-fc6119fccc28"
+    },
+    "created_time": "2024-10-04T13:51:00.000Z",
+    "last_edited_time": "2024-10-04T13:51:00.000Z",
+    "created_by": {
+        "object": "user",
+        "id": "7f03dda0-a132-49d7-b8b2-29c9ed1b1f0e"
+    },
+    "last_edited_by": {
+        "object": "user",
+        "id": "7f03dda0-a132-49d7-b8b2-29c9ed1b1f0e"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "audio",
+    "audio": {
+        "caption": [],
+        "type": "file",
+        "file": {
+            "url": "https://prod-files-secure.s3.us-west-2.amazonaws.com/f382a7b8-f6a1-420f-9b7c-382458696860/d294b65b-924f-4168-8794-1d845d6dcdaf/file_example_MP3_2MG.mp3",
+            "expiry_time": "2024-10-04T14:59:13.048Z"
+        }
+    }
+}

--- a/tests/Resource/BlockTest.php
+++ b/tests/Resource/BlockTest.php
@@ -6,6 +6,7 @@ namespace Brd6\Test\NotionSdkPhp\Resource;
 
 use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
 use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
+use Brd6\NotionSdkPhp\Resource\Block\AudioBlock;
 use Brd6\NotionSdkPhp\Resource\Block\CalloutBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ChildPageBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ParagraphBlock;
@@ -14,6 +15,7 @@ use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
 use Brd6\NotionSdkPhp\Resource\File\Emoji;
 use Brd6\NotionSdkPhp\Resource\Property\CalloutProperty;
 use Brd6\NotionSdkPhp\Resource\Property\ChildPageProperty;
+use Brd6\NotionSdkPhp\Resource\Property\FileProperty;
 use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
 use Brd6\NotionSdkPhp\Resource\Property\ParagraphProperty;
 use Brd6\NotionSdkPhp\Resource\Property\SyncedBlockProperty;
@@ -272,5 +274,27 @@ class BlockTest extends TestCase
         $this->assertArrayHasKey('text', $richTextData);
         $this->assertArrayHasKey('content', $richTextData['text']);
         $this->assertEquals('', $richTextData['text']['content']);
+    }
+
+    public function testAudioBlock(): void
+    {
+        $block = AbstractBlock::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_audio_200.json'),
+                true,
+            ),
+        );
+
+        $this->assertInstanceOf(AudioBlock::class, $block);
+        $this->assertEquals('audio', $block->getType());
+        $this->assertNotNull($block->getAudio());
+        $this->assertInstanceOf(AbstractFile::class, $block->getAudio());
+
+        $audioFile = $block->getAudio()->getFile();
+
+        $this->assertNotNull($audioFile);
+        $this->assertInstanceOf(FileProperty::class, $audioFile);
+        $this->assertNotEmpty($audioFile->getUrl());
+        $this->assertNotEmpty($audioFile->getExpiryTime());
     }
 }


### PR DESCRIPTION
## Description
Support for `AudioBlock` added to handle audio content in Notion documents.

## Motivation and context
Enables working with audio blocks, improving media support in the SDK.

## How has this been tested?
Tested with `testAudioBlock` to validate correct parsing of audio block data.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
