### PR TITLE
fix(table): allow empty cells

### DIFF
--- a/src/Resource/Property/TableRowProperty.php
+++ b/src/Resource/Property/TableRowProperty.php
@@ -13,7 +13,7 @@ use function count;
 class TableRowProperty extends AbstractProperty
 {
     /**
-     * @var AbstractRichText[]
+     * @var array<AbstractRichText|null>
      */
     protected array $cells = [];
 
@@ -41,7 +41,7 @@ class TableRowProperty extends AbstractProperty
     /**
      * @param array $cellsRawData
      *
-     * @return AbstractRichText[]
+     * @return array<AbstractRichText|null>
      *
      * @throws InvalidRichTextException
      * @throws UnsupportedRichTextTypeException
@@ -52,21 +52,21 @@ class TableRowProperty extends AbstractProperty
 
         /** @var array $cellData */
         foreach ($cellsRawData as $cellData) {
-            if (count($cellData) === 0) {
-                continue;
+            $rawData = [];
+
+            if (count($cellData) > 0) {
+                /** @var array $rawData */
+                $rawData = $cellData[0];
             }
 
-            /** @var array $rawData */
-            $rawData = $cellData[0];
-
-            $cells[] = AbstractRichText::fromRawData($rawData);
+            $cells[] = count($rawData) > 0 ? AbstractRichText::fromRawData($rawData) : null;
         }
 
         return $cells;
     }
 
     /**
-     * @return AbstractRichText[]
+     * @return array<AbstractRichText|null>
      */
     public function getCells(): array
     {
@@ -74,7 +74,7 @@ class TableRowProperty extends AbstractProperty
     }
 
     /**
-     * @param AbstractRichText[] $cells
+     * @param array<AbstractRichText|null> $cells
      */
     public function setCells(array $cells): self
     {


### PR DESCRIPTION
## Description
Fixed issue where empty cells in `TableRowBlock` were skipped. They are now correctly parsed as `null`.

## Motivation and context
Ensures empty cells are handled properly in `TableRowBlock`, preventing skipped data.

## How has this been tested?
Tested with mock HTTP client and unit tests for empty and non-empty cells.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
