### PR TITLE
feat: allow multi rich text in table cells

### DIFF
--- a/src/Resource/Property/TableRowProperty.php
+++ b/src/Resource/Property/TableRowProperty.php
@@ -8,12 +8,13 @@ use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
 use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
 use Brd6\NotionSdkPhp\Resource\RichText\AbstractRichText;
 
+use function array_map;
 use function count;
 
 class TableRowProperty extends AbstractProperty
 {
     /**
-     * @var array<AbstractRichText|null>
+     * @var array<array<AbstractRichText>>
      */
     protected array $cells = [];
 
@@ -41,7 +42,7 @@ class TableRowProperty extends AbstractProperty
     /**
      * @param array $cellsRawData
      *
-     * @return array<AbstractRichText|null>
+     * @return array<array<AbstractRichText>>
      *
      * @throws InvalidRichTextException
      * @throws UnsupportedRichTextTypeException
@@ -55,18 +56,18 @@ class TableRowProperty extends AbstractProperty
             $rawData = [];
 
             if (count($cellData) > 0) {
-                /** @var array $rawData */
-                $rawData = $cellData[0];
+                /** @var array<AbstractRichText> $rawData */
+                $rawData = array_map(static fn (array $data) => AbstractRichText::fromRawData($data), $cellData);
             }
 
-            $cells[] = count($rawData) > 0 ? AbstractRichText::fromRawData($rawData) : null;
+            $cells[] = $rawData;
         }
 
         return $cells;
     }
 
     /**
-     * @return array<AbstractRichText|null>
+     * @return array<array<AbstractRichText>>
      */
     public function getCells(): array
     {
@@ -74,7 +75,7 @@ class TableRowProperty extends AbstractProperty
     }
 
     /**
-     * @param array<AbstractRichText|null> $cells
+     * @param array<array<AbstractRichText>> $cells
      */
     public function setCells(array $cells): self
     {

--- a/tests/Endpoint/BlocksEndpointTest.php
+++ b/tests/Endpoint/BlocksEndpointTest.php
@@ -363,7 +363,7 @@ class BlocksEndpointTest extends TestCase
         $this->assertGreaterThan(0, count($resultBlock->getTableRow()->getCells()));
 
         /** @var Text $text */
-        $text = $resultBlock->getTableRow()->getCells()[0];
+        $text = $resultBlock->getTableRow()->getCells()[0][0];
 
         $this->assertInstanceOf(Text::class, $text);
 
@@ -396,16 +396,16 @@ class BlocksEndpointTest extends TestCase
 
         $cells = $resultBlock->getTableRow()->getCells();
 
-        $this->assertInstanceOf(Text::class, $cells[0]);
-        $this->assertEquals('Header 1', $cells[0]->getText()->getContent());
-        $this->assertInstanceOf(Text::class, $cells[1]);
-        $this->assertEquals('Header 2', $cells[1]->getText()->getContent());
-        $this->assertNull($cells[2]);
+        $this->assertInstanceOf(Text::class, $cells[0][0]);
+        $this->assertEquals('Header 1', $cells[0][0]->getText()->getContent());
+        $this->assertInstanceOf(Text::class, $cells[1][0]);
+        $this->assertEquals('Header 2', $cells[1][0]->getText()->getContent());
+        $this->assertEmpty($cells[2]);
 
         $resultBlock2 = $paginationResponse->getResults()[1];
         $cells2 = $resultBlock2->getTableRow()->getCells();
-        $this->assertInstanceOf(Text::class, $cells2[0]);
-        $this->assertEquals('Content', $cells2[0]->getText()->getContent());
-        $this->assertNull($cells2[2]);
+        $this->assertInstanceOf(Text::class, $cells2[0][0]);
+        $this->assertEquals('Content', $cells2[0][0]->getText()->getContent());
+        $this->assertEmpty($cells2[2]);
     }
 }


### PR DESCRIPTION
## Description
Added support for multiple rich text objects in table row cells. Cells can now contain multiple rich text entries instead of just one.

## Motivation and context
This change allows proper handling of multiple rich text objects in cells, improving flexibility and data accuracy.

## How has this been tested?
Tested with updated unit tests to verify multi-rich-text cells and empty cells are correctly handled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
