### PR TITLE
feat(comments): implement Comment object and endpoints

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ namespace Brd6\NotionSdkPhp;
 
 use Brd6\NotionSdkPhp\Constant\NotionErrorCodeConstant;
 use Brd6\NotionSdkPhp\Endpoint\BlocksEndpoint;
+use Brd6\NotionSdkPhp\Endpoint\CommentsEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\DatabasesEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\PagesEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\SearchEndpoint;
@@ -44,6 +45,7 @@ class Client
     private ClientOptions $options;
     private HttpMethodsClientInterface $httpClient;
     private BlocksEndpoint $blocksEndpoint;
+    private CommentsEndpoint $commentsEndpoint;
     private UsersEndpoint $usersEndpoint;
     private PagesEndpoint $pagesEndpoint;
     private DatabasesEndpoint $databasesEndpoint;
@@ -55,6 +57,7 @@ class Client
         $this->initializeHttpClient();
 
         $this->blocksEndpoint = new BlocksEndpoint($this);
+        $this->commentsEndpoint = new CommentsEndpoint($this);
         $this->usersEndpoint = new UsersEndpoint($this);
         $this->pagesEndpoint = new PagesEndpoint($this);
         $this->databasesEndpoint = new DatabasesEndpoint($this);
@@ -156,6 +159,11 @@ class Client
     public function blocks(): BlocksEndpoint
     {
         return $this->blocksEndpoint;
+    }
+
+    public function comments(): CommentsEndpoint
+    {
+        return $this->commentsEndpoint;
     }
 
     public function users(): UsersEndpoint

--- a/src/Endpoint/CommentsEndpoint.php
+++ b/src/Endpoint/CommentsEndpoint.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Exception\ApiResponseException;
+use Brd6\NotionSdkPhp\Exception\HttpResponseException;
+use Brd6\NotionSdkPhp\Exception\InvalidFileException;
+use Brd6\NotionSdkPhp\Exception\InvalidPaginationResponseException;
+use Brd6\NotionSdkPhp\Exception\InvalidParentException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceTypeException;
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedFileTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedPaginationResponseTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedParentTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
+use Brd6\NotionSdkPhp\RequestParameters;
+use Brd6\NotionSdkPhp\Resource\Comment;
+use Brd6\NotionSdkPhp\Resource\Pagination\CommentResults;
+use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
+use Http\Client\Exception;
+
+use function array_merge;
+use function count;
+use function strlen;
+
+class CommentsEndpoint extends AbstractEndpoint
+{
+    /**
+     * @throws ApiResponseException
+     * @throws HttpResponseException
+     * @throws InvalidPaginationResponseException
+     * @throws RequestTimeoutException
+     * @throws UnsupportedPaginationResponseTypeException
+     * @throws Exception
+     * @throws InvalidFileException
+     * @throws InvalidParentException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws InvalidRichTextException
+     * @throws UnsupportedFileTypeException
+     * @throws UnsupportedParentTypeException
+     * @throws UnsupportedRichTextTypeException
+     * @throws UnsupportedUserTypeException
+     */
+    public function retrieve(string $blockId, ?PaginationRequest $paginationRequest = null): CommentResults
+    {
+        $query = ['block_id' => $blockId];
+
+        if ($paginationRequest !== null) {
+            $query = array_merge($query, $paginationRequest->toArray());
+        }
+
+        $requestParameters = (new RequestParameters())
+            ->setPath('comments')
+            ->setMethod('GET')
+            ->setQuery($query);
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var CommentResults $commentResults */
+        $commentResults = CommentResults::fromRawData($rawData);
+
+        return $commentResults;
+    }
+
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidFileException
+     * @throws InvalidParentException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws InvalidRichTextException
+     * @throws RequestTimeoutException
+     * @throws UnsupportedFileTypeException
+     * @throws UnsupportedParentTypeException
+     * @throws UnsupportedRichTextTypeException
+     * @throws UnsupportedUserTypeException
+     */
+    public function create(Comment $comment): Comment
+    {
+        $data = [];
+        $parent = $comment->getParent();
+
+        if ($parent !== null) {
+            $data['parent'] = $parent->toArray();
+        } elseif (strlen($comment->getDiscussionId()) > 0) {
+            $data['discussion_id'] = $comment->getDiscussionId();
+        } else {
+            throw new InvalidParentException('Either parent.page_id or discussion_id must be provided');
+        }
+
+        $richTextData = [];
+        foreach ($comment->getRichText() as $richText) {
+            $richTextData[] = $richText->toArray();
+        }
+        $data['rich_text'] = $richTextData;
+
+        if (count($comment->getAttachments()) > 0) {
+            $attachmentsData = [];
+            foreach ($comment->getAttachments() as $attachment) {
+                $attachmentsData[] = $attachment->toArray();
+            }
+            $data['attachments'] = $attachmentsData;
+        }
+
+        $requestParameters = (new RequestParameters())
+            ->setPath('comments')
+            ->setMethod('POST')
+            ->setBody($data);
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var Comment $createdComment */
+        $createdComment = Comment::fromRawData($rawData);
+
+        return $createdComment;
+    }
+}

--- a/src/Resource/Comment.php
+++ b/src/Resource/Comment.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource;
+
+use Brd6\NotionSdkPhp\Exception\InvalidFileException;
+use Brd6\NotionSdkPhp\Exception\InvalidParentException;
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedFileTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedParentTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
+use Brd6\NotionSdkPhp\Resource\RichText\AbstractRichText;
+use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
+use DateTimeImmutable;
+
+class Comment extends AbstractResource
+{
+    public const RESOURCE_TYPE = 'comment';
+
+    protected ?AbstractParentProperty $parent = null;
+    protected string $discussionId = '';
+    protected ?DateTimeImmutable $createdTime = null;
+    protected ?DateTimeImmutable $lastEditedTime = null;
+    protected ?UserInterface $createdBy = null;
+
+    /**
+     * @var array<AbstractRichText>
+     */
+    protected array $richText = [];
+
+    /**
+     * @var array<CommentAttachment>
+     */
+    protected array $attachments = [];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->object = self::RESOURCE_TYPE;
+    }
+
+    /**
+     * @throws InvalidFileException
+     * @throws InvalidParentException
+     * @throws InvalidRichTextException
+     * @throws UnsupportedFileTypeException
+     * @throws UnsupportedParentTypeException
+     * @throws UnsupportedRichTextTypeException
+     * @throws UnsupportedUserTypeException
+     */
+    protected function initialize(): void
+    {
+        $this->parent = isset($this->getRawData()['parent']) ?
+            AbstractParentProperty::fromRawData((array) $this->getRawData()['parent']) :
+            null;
+
+        $this->discussionId = (string) ($this->getRawData()['discussion_id'] ?? '');
+
+        $this->createdTime = isset($this->getRawData()['created_time']) ?
+            new DateTimeImmutable((string) $this->getRawData()['created_time']) :
+            null;
+
+        $this->lastEditedTime = isset($this->getRawData()['last_edited_time']) ?
+            new DateTimeImmutable((string) $this->getRawData()['last_edited_time']) :
+            null;
+
+        $this->createdBy = isset($this->getRawData()['created_by']) ?
+            AbstractUser::fromRawData((array) $this->getRawData()['created_by']) :
+            null;
+
+        /** @var array<array> $richTextData */
+        $richTextData = (array) ($this->getRawData()['rich_text'] ?? []);
+        foreach ($richTextData as $richTextItem) {
+            $this->richText[] = AbstractRichText::fromRawData($richTextItem);
+        }
+
+        /** @var array<array> $attachmentsData */
+        $attachmentsData = (array) ($this->getRawData()['attachments'] ?? []);
+        foreach ($attachmentsData as $attachmentItem) {
+            $this->attachments[] = CommentAttachment::fromRawData($attachmentItem);
+        }
+    }
+
+    public static function getResourceType(): string
+    {
+        return self::RESOURCE_TYPE;
+    }
+
+    public function getParent(): ?AbstractParentProperty
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?AbstractParentProperty $parent): self
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    public function getDiscussionId(): string
+    {
+        return $this->discussionId;
+    }
+
+    public function setDiscussionId(string $discussionId): self
+    {
+        $this->discussionId = $discussionId;
+
+        return $this;
+    }
+
+    public function getCreatedTime(): ?DateTimeImmutable
+    {
+        return $this->createdTime;
+    }
+
+    public function setCreatedTime(?DateTimeImmutable $createdTime): self
+    {
+        $this->createdTime = $createdTime;
+
+        return $this;
+    }
+
+    public function getLastEditedTime(): ?DateTimeImmutable
+    {
+        return $this->lastEditedTime;
+    }
+
+    public function setLastEditedTime(?DateTimeImmutable $lastEditedTime): self
+    {
+        $this->lastEditedTime = $lastEditedTime;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?UserInterface
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(?UserInterface $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    /**
+     * @return array<AbstractRichText>
+     */
+    public function getRichText(): array
+    {
+        return $this->richText;
+    }
+
+    /**
+     * @param array<AbstractRichText> $richText
+     */
+    public function setRichText(array $richText): self
+    {
+        $this->richText = $richText;
+
+        return $this;
+    }
+
+    /**
+     * @return array<CommentAttachment>
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * @param array<CommentAttachment> $attachments
+     */
+    public function setAttachments(array $attachments): self
+    {
+        $this->attachments = $attachments;
+
+        return $this;
+    }
+}

--- a/src/Resource/CommentAttachment.php
+++ b/src/Resource/CommentAttachment.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource;
+
+use Brd6\NotionSdkPhp\Exception\InvalidFileException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedFileTypeException;
+use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
+
+use function strlen;
+
+class CommentAttachment extends AbstractJsonSerializable
+{
+    protected string $category = '';
+    protected ?AbstractFile $file = null;
+    private array $rawData = [];
+
+    /**
+     * @throws InvalidFileException
+     * @throws UnsupportedFileTypeException
+     */
+    public static function fromRawData(array $rawData): self
+    {
+        $attachment = new self();
+        $attachment->setRawData($rawData);
+        $attachment->initialize();
+
+        return $attachment;
+    }
+
+    protected function setRawData(array $rawData): self
+    {
+        $this->rawData = $rawData;
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidFileException
+     * @throws UnsupportedFileTypeException
+     */
+    protected function initialize(): void
+    {
+        $this->category = (string) ($this->getRawData()['category'] ?? '');
+
+        $this->file = isset($this->getRawData()['file']) ?
+            AbstractFile::fromRawData((array) $this->getRawData()['file']) :
+            null;
+    }
+
+    public function getRawData(): array
+    {
+        return $this->rawData;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    public function setCategory(string $category): self
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    public function getFile(): ?AbstractFile
+    {
+        return $this->file;
+    }
+
+    public function setFile(?AbstractFile $file): self
+    {
+        $this->file = $file;
+
+        return $this;
+    }
+
+    public function toArray(bool $ignoreEmptyValue = true, array $onlyKeys = []): array
+    {
+        $data = [];
+
+        if (strlen($this->category) > 0) {
+            $data['category'] = $this->category;
+        }
+
+        if ($this->file !== null) {
+            $data['file'] = $this->file->toArray();
+        }
+
+        return $data;
+    }
+}

--- a/src/Resource/Page/Parent/PageIdParent.php
+++ b/src/Resource/Page/Parent/PageIdParent.php
@@ -8,6 +8,11 @@ class PageIdParent extends AbstractParentProperty
 {
     protected string $pageId = '';
 
+    public function __construct()
+    {
+        $this->type = 'page_id';
+    }
+
     protected function initialize(): void
     {
         $this->pageId = (string) $this->getRawData()['page_id'];

--- a/src/Resource/Pagination/CommentResults.php
+++ b/src/Resource/Pagination/CommentResults.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Pagination;
+
+use Brd6\NotionSdkPhp\Exception\InvalidParentException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceTypeException;
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedParentTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
+use Brd6\NotionSdkPhp\Resource\Comment;
+
+use function array_map;
+
+class CommentResults extends AbstractPaginationResults
+{
+    /**
+     * @throws InvalidParentException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws InvalidRichTextException
+     * @throws UnsupportedParentTypeException
+     * @throws UnsupportedRichTextTypeException
+     * @throws UnsupportedUserTypeException
+     */
+    protected function initialize(): void
+    {
+        $this->results = isset($this->getRawData()['results']) ? array_map(
+            fn (array $resultRawData) => Comment::fromRawData($resultRawData),
+            (array) $this->getRawData()['results'],
+        ) : [];
+    }
+
+    /**
+     * @return Comment[]|array
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+}

--- a/tests/Endpoint/CommentsEndpointTest.php
+++ b/tests/Endpoint/CommentsEndpointTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Client;
+use Brd6\NotionSdkPhp\ClientOptions;
+use Brd6\NotionSdkPhp\Endpoint\CommentsEndpoint;
+use Brd6\NotionSdkPhp\Resource\Comment;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\PageIdParent;
+use Brd6\NotionSdkPhp\Resource\Pagination\CommentResults;
+use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
+use Brd6\NotionSdkPhp\Resource\RichText\Text;
+use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
+use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockResponseFactory;
+use Brd6\Test\NotionSdkPhp\TestCase;
+
+use function file_get_contents;
+use function json_decode;
+
+class CommentsEndpointTest extends TestCase
+{
+    public function testInstance(): void
+    {
+        $client = new Client();
+        $comments = new CommentsEndpoint($client);
+
+        $this->assertInstanceOf(CommentsEndpoint::class, $client->comments());
+        $this->assertInstanceOf(CommentsEndpoint::class, $comments);
+    }
+
+    public function testRetrieve(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('GET', $method);
+            $this->assertStringContainsString('comments', $url);
+            $this->assertStringContainsString('block_id=5c6a2821-6bb1-4a7e-b6e1-c50111515c3d', $url);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/comments_list_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setAuth('secret_valid-auth')
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $commentResults = $client->comments()->retrieve('5c6a2821-6bb1-4a7e-b6e1-c50111515c3d');
+
+        $this->assertInstanceOf(CommentResults::class, $commentResults);
+        $this->assertEquals('list', $commentResults->getObject());
+        $this->assertEquals('comment', $commentResults->getType());
+
+        $comments = $commentResults->getResults();
+        $this->assertCount(2, $comments);
+        $this->assertInstanceOf(Comment::class, $comments[0]);
+    }
+
+    public function testRetrieveWithPagination(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('GET', $method);
+            $this->assertStringContainsString('comments', $url);
+            $this->assertStringContainsString('block_id=5c6a2821-6bb1-4a7e-b6e1-c50111515c3d', $url);
+            $this->assertStringContainsString('page_size=50', $url);
+            $this->assertStringContainsString('start_cursor=abc123', $url);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/comments_list_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setAuth('secret_valid-auth')
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $paginationRequest = (new PaginationRequest())
+            ->setPageSize(50)
+            ->setStartCursor('abc123');
+
+        $commentResults = $client->comments()->retrieve(
+            '5c6a2821-6bb1-4a7e-b6e1-c50111515c3d',
+            $paginationRequest,
+        );
+
+        $this->assertInstanceOf(CommentResults::class, $commentResults);
+    }
+
+    public function testCreatePageComment(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('POST', $method);
+            $this->assertStringContainsString('comments', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('parent', $body);
+            $this->assertArrayHasKey('type', $body['parent']);
+            $this->assertArrayHasKey('page_id', $body['parent']);
+            $this->assertEquals('page_id', $body['parent']['type']);
+            $this->assertEquals('5c6a2821-6bb1-4a7e-b6e1-c50111515c3d', $body['parent']['page_id']);
+            $this->assertArrayHasKey('rich_text', $body);
+            $this->assertStringContainsString('Hello from integration', $body['rich_text'][0]['text']['content']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/comment_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $comment = new Comment();
+        $comment->setParent((new PageIdParent())->setPageId('5c6a2821-6bb1-4a7e-b6e1-c50111515c3d'));
+        $comment->setRichText([Text::fromContent('Hello from integration')]);
+
+        $createdComment = $client->comments()->create($comment);
+
+        $this->assertInstanceOf(Comment::class, $createdComment);
+        $this->assertEquals('7a793800-3e55-4d5e-8009-2261de026179', $createdComment->getId());
+    }
+
+    public function testCreateDiscussionComment(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('POST', $method);
+            $this->assertStringContainsString('comments', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('discussion_id', $body);
+            $this->assertEquals('f4be6752-a539-4da2-a8a9-c3953e13bc0b', $body['discussion_id']);
+            $this->assertArrayHasKey('rich_text', $body);
+            $this->assertStringContainsString('Reply to discussion', $body['rich_text'][0]['text']['content']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/comment_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $comment = new Comment();
+        $comment->setDiscussionId('f4be6752-a539-4da2-a8a9-c3953e13bc0b');
+        $comment->setRichText([Text::fromContent('Reply to discussion')]);
+
+        $createdComment = $client->comments()->create($comment);
+
+        $this->assertInstanceOf(Comment::class, $createdComment);
+        $this->assertEquals('7a793800-3e55-4d5e-8009-2261de026179', $createdComment->getId());
+    }
+}

--- a/tests/Fixtures/comment_200.json
+++ b/tests/Fixtures/comment_200.json
@@ -1,0 +1,46 @@
+{
+  "object": "comment",
+  "id": "7a793800-3e55-4d5e-8009-2261de026179",
+  "parent": {
+    "type": "page_id",
+    "page_id": "5c6a2821-6bb1-4a7e-b6e1-c50111515c3d"
+  },
+  "discussion_id": "f4be6752-a539-4da2-a8a9-c3953e13bc0b",
+  "created_time": "2022-07-15T21:17:00.000Z",
+  "last_edited_time": "2022-07-15T21:17:00.000Z",
+  "created_by": {
+    "object": "user",
+    "id": "e450a39e-9051-4d36-bc4e-8581611fc592"
+  },
+  "rich_text": [
+    {
+      "type": "text",
+      "text": {
+        "content": "Hello world",
+        "link": null
+      },
+      "annotations": {
+        "bold": false,
+        "italic": false,
+        "strikethrough": false,
+        "underline": false,
+        "code": false,
+        "color": "default"
+      },
+      "plain_text": "Hello world",
+      "href": null
+    }
+  ],
+  "attachments": [
+    {
+      "category": "image",
+      "file": {
+        "type": "file",
+        "file": {
+          "url": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/9bc6c6e0-32b8-4d55-8c12-3ae931f43a01/image.png",
+          "expiry_time": "2025-06-10T21:58:51.599Z"
+        }
+      }
+    }
+  ]
+} 

--- a/tests/Fixtures/comments_list_200.json
+++ b/tests/Fixtures/comments_list_200.json
@@ -1,0 +1,89 @@
+{
+  "object": "list",
+  "type": "comment",
+  "has_more": false,
+  "next_cursor": null,
+  "results": [
+    {
+      "object": "comment",
+      "id": "7a793800-3e55-4d5e-8009-2261de026179",
+      "parent": {
+        "type": "page_id",
+        "page_id": "5c6a2821-6bb1-4a7e-b6e1-c50111515c3d"
+      },
+      "discussion_id": "f4be6752-a539-4da2-a8a9-c3953e13bc0b",
+      "created_time": "2022-07-15T21:17:00.000Z",
+      "last_edited_time": "2022-07-15T21:17:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "e450a39e-9051-4d36-bc4e-8581611fc592"
+      },
+      "rich_text": [
+        {
+          "type": "text",
+          "text": {
+            "content": "Hello world",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "Hello world",
+          "href": null
+        }
+      ],
+      "attachments": [
+        {
+          "category": "image",
+          "file": {
+            "type": "file",
+            "file": {
+              "url": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/9bc6c6e0-32b8-4d55-8c12-3ae931f43a01/image.png",
+              "expiry_time": "2025-06-10T21:58:51.599Z"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "object": "comment",
+      "id": "8b3cfeed-c0da-451e-8f18-f7086c321980",
+      "parent": {
+        "type": "page_id",
+        "page_id": "5c6a2821-6bb1-4a7e-b6e1-c50111515c3d"
+      },
+      "discussion_id": "f4be6752-a539-4da2-a8a9-c3953e13bc0b",
+      "created_time": "2022-07-15T21:18:00.000Z",
+      "last_edited_time": "2022-07-15T21:18:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "e450a39e-9051-4d36-bc4e-8581611fc592"
+      },
+      "rich_text": [
+        {
+          "type": "text",
+          "text": {
+            "content": "This is another comment",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "This is another comment",
+          "href": null
+        }
+      ],
+      "attachments": []
+    }
+  ]
+} 

--- a/tests/Resource/CommentTest.php
+++ b/tests/Resource/CommentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource;
+
+use Brd6\NotionSdkPhp\Resource\Comment;
+use Brd6\NotionSdkPhp\Resource\CommentAttachment;
+use Brd6\NotionSdkPhp\Resource\File\File;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\PageIdParent;
+use Brd6\NotionSdkPhp\Resource\RichText\Text;
+use Brd6\NotionSdkPhp\Resource\User\PartialUser;
+use Brd6\Test\NotionSdkPhp\TestCase;
+use DateTimeImmutable;
+
+use function file_get_contents;
+use function json_decode;
+
+class CommentTest extends TestCase
+{
+    public function testFromRawData(): void
+    {
+        $rawData = json_decode(
+            (string) file_get_contents('tests/Fixtures/comment_200.json'),
+            true,
+        );
+
+        $comment = Comment::fromRawData($rawData);
+
+        $this->assertEquals('comment', $comment::getResourceType());
+        $this->assertEquals('7a793800-3e55-4d5e-8009-2261de026179', $comment->getId());
+        $this->assertEquals('f4be6752-a539-4da2-a8a9-c3953e13bc0b', $comment->getDiscussionId());
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $comment->getCreatedTime());
+        $this->assertEquals('2022-07-15T21:17:00.000Z', $comment->getCreatedTime()->format('Y-m-d\TH:i:s.v\Z'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $comment->getLastEditedTime());
+        $this->assertEquals('2022-07-15T21:17:00.000Z', $comment->getLastEditedTime()->format('Y-m-d\TH:i:s.v\Z'));
+
+        $this->assertInstanceOf(PartialUser::class, $comment->getCreatedBy());
+        $this->assertEquals('e450a39e-9051-4d36-bc4e-8581611fc592', $comment->getCreatedBy()->getId());
+
+        $this->assertInstanceOf(PageIdParent::class, $comment->getParent());
+        $this->assertEquals('5c6a2821-6bb1-4a7e-b6e1-c50111515c3d', $comment->getParent()->getPageId());
+
+        $richText = $comment->getRichText();
+        $this->assertCount(1, $richText);
+        $this->assertInstanceOf(Text::class, $richText[0]);
+        $this->assertEquals('Hello world', $richText[0]->getPlainText());
+
+        $attachments = $comment->getAttachments();
+        $this->assertCount(1, $attachments);
+        $this->assertInstanceOf(CommentAttachment::class, $attachments[0]);
+        $this->assertEquals('image', $attachments[0]->getCategory());
+        $this->assertInstanceOf(File::class, $attachments[0]->getFile());
+    }
+}

--- a/tests/Resource/Page/Parent/PageIdParentTest.php
+++ b/tests/Resource/Page/Parent/PageIdParentTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource\Page\Parent;
+
+use Brd6\NotionSdkPhp\Resource\Page\Parent\PageIdParent;
+use Brd6\Test\NotionSdkPhp\TestCase;
+
+class PageIdParentTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $pageId = 'c7b7a433-2345-4b57-93f8-8883a31e8529';
+
+        $parent = (new PageIdParent())
+            ->setPageId($pageId);
+
+        $this->assertEquals(
+            [
+                'type' => 'page_id',
+                'page_id' => $pageId,
+            ],
+            $parent->toArray(),
+        );
+    }
+}

--- a/tests/Resource/Pagination/CommentResultsTest.php
+++ b/tests/Resource/Pagination/CommentResultsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource\Pagination;
+
+use Brd6\NotionSdkPhp\Resource\Comment;
+use Brd6\NotionSdkPhp\Resource\Pagination\CommentResults;
+use Brd6\Test\NotionSdkPhp\TestCase;
+
+use function file_get_contents;
+use function json_decode;
+
+class CommentResultsTest extends TestCase
+{
+    public function testFromRawData(): void
+    {
+        $rawData = json_decode(
+            (string) file_get_contents('tests/Fixtures/comments_list_200.json'),
+            true,
+        );
+
+        $commentResults = CommentResults::fromRawData($rawData);
+
+        $this->assertEquals('list', $commentResults->getObject());
+        $this->assertEquals('comment', $commentResults->getType());
+        $this->assertFalse($commentResults->isHasMore());
+        $this->assertNull($commentResults->getNextCursor());
+
+        $results = $commentResults->getResults();
+        $this->assertCount(2, $results);
+
+        $this->assertInstanceOf(Comment::class, $results[0]);
+        $this->assertEquals('7a793800-3e55-4d5e-8009-2261de026179', $results[0]->getId());
+        $this->assertEquals('Hello world', $results[0]->getRichText()[0]->getPlainText());
+
+        $this->assertInstanceOf(Comment::class, $results[1]);
+        $this->assertEquals('8b3cfeed-c0da-451e-8f18-f7086c321980', $results[1]->getId());
+        $this->assertEquals('This is another comment', $results[1]->getRichText()[0]->getPlainText());
+    }
+}


### PR DESCRIPTION
## Description
Implements Comments API for the Notion SDK, including Comment resource, CommentAttachment, pagination support, and endpoints for retrieving and creating comments.

## Motivation and context
Adds missing Comments API functionality to achieve feature parity with the official Notion API. Users can now interact with comments on pages and blocks programmatically.

## How has this been tested?
- Created integration tests for endpoints with mock HTTP responses
- Tested real API calls with working Notion integration
- Added regression tests to prevent serialization issues

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.