### PR TITLE
Feat/page archived serialization fix

### DIFF
--- a/src/Endpoint/PagesEndpoint.php
+++ b/src/Endpoint/PagesEndpoint.php
@@ -68,7 +68,7 @@ class PagesEndpoint extends AbstractEndpoint
     {
         $childrenData = array_map(fn (AbstractBlock $block) => $block->toArray(), $children);
 
-        $data = array_merge($page->toArray(), ['children' => $childrenData]);
+        $data = array_merge($page->toArrayForCreate(), ['children' => $childrenData]);
 
         $requestParameters = (new RequestParameters())
             ->setPath('pages')

--- a/src/Resource/AbstractJsonSerializable.php
+++ b/src/Resource/AbstractJsonSerializable.php
@@ -7,7 +7,9 @@ namespace Brd6\NotionSdkPhp\Resource;
 use Brd6\NotionSdkPhp\Util\ArrayHelper;
 use JsonSerializable;
 
+use function array_fill_keys;
 use function array_filter;
+use function array_intersect_key;
 use function count;
 use function get_object_vars;
 use function in_array;
@@ -49,6 +51,17 @@ abstract class AbstractJsonSerializable implements JsonSerializable
         $this->onlyKeys = [];
 
         return $data;
+    }
+
+    /**
+     * @param string[] $onlyKeys
+     */
+    public function toArrayStrict(array $onlyKeys, bool $ignoreEmptyValue = true): array
+    {
+        return array_intersect_key(
+            $this->toArray($ignoreEmptyValue),
+            array_fill_keys($onlyKeys, true),
+        );
     }
 
     /**

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -20,6 +20,7 @@ use DateTimeImmutable;
 class Page extends AbstractResource
 {
     public const RESOURCE_TYPE = 'page';
+    private const CREATE_ACCEPTED_KEYS = ['object', 'properties', 'parent', 'icon', 'cover'];
     private const UPDATE_ACCEPTED_KEYS = ['properties', 'archived', 'icon', 'cover'];
 
     protected ?DateTimeImmutable $createdTime = null;
@@ -45,6 +46,16 @@ class Page extends AbstractResource
         $this->object = self::RESOURCE_TYPE;
     }
 
+    public function toArrayForCreate(): array
+    {
+        $data = $this->toArrayStrict(self::CREATE_ACCEPTED_KEYS);
+        if ($this->archived) {
+            $data['archived'] = true;
+        }
+
+        return $data;
+    }
+
     public function toArrayForUpdate(): array
     {
         return $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
@@ -65,7 +76,7 @@ class Page extends AbstractResource
         $this->createdTime = new DateTimeImmutable((string) $this->getRawData()['created_time']);
         $this->lastEditedTime = new DateTimeImmutable((string) $this->getRawData()['last_edited_time']);
         $this->lastEditedBy = AbstractUser::fromRawData((array) $this->getRawData()['last_edited_by']);
-        $this->archived = (bool) $this->getRawData()['archived'];
+        $this->archived = (bool) ($this->getRawData()['archived'] ?? false);
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -17,6 +17,8 @@ use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\AbstractPropertyValue;
 use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
 use DateTimeImmutable;
 
+use function array_key_exists;
+
 class Page extends AbstractResource
 {
     public const RESOURCE_TYPE = 'page';
@@ -27,7 +29,7 @@ class Page extends AbstractResource
     protected ?UserInterface $createdBy = null;
     protected ?DateTimeImmutable $lastEditedTime = null;
     protected ?UserInterface $lastEditedBy = null;
-    protected bool $archived = false;
+    protected ?bool $archived = null;
     protected ?AbstractFile $icon = null;
     protected ?AbstractFile $cover = null;
 
@@ -49,8 +51,9 @@ class Page extends AbstractResource
     public function toArrayForCreate(): array
     {
         $data = $this->toArrayStrict(self::CREATE_ACCEPTED_KEYS);
-        if ($this->archived) {
-            $data['archived'] = true;
+
+        if ($this->archived !== null) {
+            $data['archived'] = $this->archived;
         }
 
         return $data;
@@ -58,7 +61,13 @@ class Page extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        return $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+        $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+
+        if ($this->archived === null) {
+            unset($data['archived']);
+        }
+
+        return $data;
     }
 
     /**
@@ -76,7 +85,9 @@ class Page extends AbstractResource
         $this->createdTime = new DateTimeImmutable((string) $this->getRawData()['created_time']);
         $this->lastEditedTime = new DateTimeImmutable((string) $this->getRawData()['last_edited_time']);
         $this->lastEditedBy = AbstractUser::fromRawData((array) $this->getRawData()['last_edited_by']);
-        $this->archived = (bool) ($this->getRawData()['archived'] ?? false);
+        $this->archived = array_key_exists('archived', $this->getRawData())
+            ? (bool) $this->getRawData()['archived']
+            : null;
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;
@@ -143,7 +154,7 @@ class Page extends AbstractResource
 
     public function isArchived(): bool
     {
-        return $this->archived;
+        return $this->archived ?? false;
     }
 
     public function setArchived(bool $archived): self

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -362,16 +362,19 @@ class PagesEndpointTest extends TestCase
         $this->assertNotEmpty($pageCreated->getId());
     }
 
-    public function testCreatePageSendsArchivedWhenExplicitlySet(): void
+    /**
+     * @dataProvider archivedValuesProvider
+     */
+    public function testCreatePageSendsArchivedWhenExplicitlySet(bool $archived): void
     {
-        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use ($archived) {
             $this->assertStringContainsString('POST', $method);
             $this->assertStringContainsString('pages', $url);
 
             /** @var array $body */
             $body = json_decode($options['body'], true);
             $this->assertArrayHasKey('archived', $body);
-            $this->assertTrue($body['archived']);
+            $this->assertSame($archived, $body['archived']);
 
             return new MockResponseFactory(
                 (string) file_get_contents('tests/Fixtures/client_pages_create_page_200.json'),
@@ -387,13 +390,13 @@ class PagesEndpointTest extends TestCase
         $page->setProperties([
             'title' => (new TitlePropertyValue())->setTitle([Text::fromContent("It's works!")]),
         ]);
-        $page->setArchived(true);
+        $page->setArchived($archived);
 
         $pageCreated = $client->pages()->create($page);
         $this->assertNotEmpty($pageCreated->getId());
     }
 
-    public function testUpdatePageSendsArchivedFalseWhenUnset(): void
+    public function testUpdatePageDoesNotSendArchivedWhenUnset(): void
     {
         $httpClient = new MockHttpClient(function ($method, $url, $options) {
             $this->assertStringContainsString('PATCH', $method);
@@ -401,8 +404,7 @@ class PagesEndpointTest extends TestCase
 
             /** @var array $body */
             $body = json_decode($options['body'], true);
-            $this->assertArrayHasKey('archived', $body);
-            $this->assertFalse($body['archived']);
+            $this->assertArrayNotHasKey('archived', $body);
 
             return new MockResponseFactory(
                 (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
@@ -423,16 +425,19 @@ class PagesEndpointTest extends TestCase
         $this->assertNotEmpty($pageUpdated->getProperties());
     }
 
-    public function testUpdatePageSendsArchivedWhenExplicitlySetTrue(): void
+    /**
+     * @dataProvider archivedValuesProvider
+     */
+    public function testUpdatePageSendsArchivedWhenExplicitlySet(bool $archived): void
     {
-        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use ($archived) {
             $this->assertStringContainsString('PATCH', $method);
             $this->assertStringContainsString('pages/1e7e638f78864ec591ea54ec7016e146', $url);
 
             /** @var array $body */
             $body = json_decode($options['body'], true);
             $this->assertArrayHasKey('archived', $body);
-            $this->assertTrue($body['archived']);
+            $this->assertSame($archived, $body['archived']);
 
             return new MockResponseFactory(
                 (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
@@ -448,10 +453,21 @@ class PagesEndpointTest extends TestCase
         $page->setProperties([
             'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('New title!')]),
         ]);
-        $page->setArchived(true);
+        $page->setArchived($archived);
 
         $pageUpdated = $client->pages()->update($page);
         $this->assertNotEmpty($pageUpdated->getProperties());
+    }
+
+    /**
+     * @return bool[][]
+     */
+    public static function archivedValuesProvider(): array
+    {
+        return [
+            [false],
+            [true],
+        ];
     }
 
     public function testCreatePageWithDataSourceParent(): void

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -36,9 +36,11 @@ use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
 use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockResponseFactory;
 use Brd6\Test\NotionSdkPhp\TestCase;
 
+use function array_keys;
 use function count;
 use function file_get_contents;
 use function json_decode;
+use function sort;
 
 class PagesEndpointTest extends TestCase
 {
@@ -253,6 +255,202 @@ class PagesEndpointTest extends TestCase
 
         $pageUpdated = $client->pages()->update($page);
 
+        $this->assertNotEmpty($pageUpdated->getProperties());
+    }
+
+    public function testUpdatePageFromRetrievedInstancePreservesExistingUpdatePayloadShape(): void
+    {
+        $requestCount = 0;
+
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use (&$requestCount) {
+            $requestCount++;
+
+            if ($requestCount === 1) {
+                $this->assertSame('GET', $method);
+                $this->assertStringContainsString('pages/4a808e6e-8845-4d49-a447-fb2a4c460f6f', $url);
+
+                return new MockResponseFactory(
+                    (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                    [
+                        'http_code' => 200,
+                    ],
+                );
+            }
+
+            if ($requestCount === 2) {
+                $this->assertSame('PATCH', $method);
+                $this->assertStringContainsString('pages/4a808e6e-8845-4d49-a447-fb2a4c460f6f', $url);
+
+                /** @var array $body */
+                $body = json_decode($options['body'], true);
+
+                $expectedKeys = [
+                    'object',
+                    'id',
+                    'created_time',
+                    'created_by',
+                    'last_edited_time',
+                    'last_edited_by',
+                    'archived',
+                    'icon',
+                    'cover',
+                    'properties',
+                    'parent',
+                    'url',
+                ];
+
+                $actualKeys = array_keys($body);
+                sort($expectedKeys);
+                sort($actualKeys);
+                $this->assertSame($expectedKeys, $actualKeys);
+                $this->assertFalse($body['archived']);
+                $this->assertStringContainsString(
+                    'Updated from retrieved instance',
+                    $body['properties']['title']['title'][0]['text']['content'],
+                );
+
+                return new MockResponseFactory(
+                    (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                    [
+                        'http_code' => 200,
+                    ],
+                );
+            }
+
+            $this->fail("Unexpected request count: {$requestCount}");
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = $client->pages()->retrieve('4a808e6e-8845-4d49-a447-fb2a4c460f6f');
+        $page->setProperties([
+            'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Updated from retrieved instance')]),
+        ]);
+
+        $pageUpdated = $client->pages()->update($page);
+
+        $this->assertSame(2, $requestCount);
+        $this->assertNotEmpty($pageUpdated->getId());
+    }
+
+    public function testCreatePageDoesNotSendArchivedWhenUnset(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('POST', $method);
+            $this->assertStringContainsString('pages', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertArrayNotHasKey('archived', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_create_page_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $page = new Page();
+        $page->setParent((new PageIdParent())->setPageId('4a808e6e88454d49a447fb2a4c460f6f'));
+        $page->setProperties([
+            'title' => (new TitlePropertyValue())->setTitle([Text::fromContent("It's works!")]),
+        ]);
+
+        $pageCreated = $client->pages()->create($page);
+        $this->assertNotEmpty($pageCreated->getId());
+    }
+
+    public function testCreatePageSendsArchivedWhenExplicitlySet(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('POST', $method);
+            $this->assertStringContainsString('pages', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertArrayHasKey('archived', $body);
+            $this->assertTrue($body['archived']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_create_page_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $page = new Page();
+        $page->setParent((new PageIdParent())->setPageId('4a808e6e88454d49a447fb2a4c460f6f'));
+        $page->setProperties([
+            'title' => (new TitlePropertyValue())->setTitle([Text::fromContent("It's works!")]),
+        ]);
+        $page->setArchived(true);
+
+        $pageCreated = $client->pages()->create($page);
+        $this->assertNotEmpty($pageCreated->getId());
+    }
+
+    public function testUpdatePageSendsArchivedFalseWhenUnset(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('PATCH', $method);
+            $this->assertStringContainsString('pages/1e7e638f78864ec591ea54ec7016e146', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertArrayHasKey('archived', $body);
+            $this->assertFalse($body['archived']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $page = new Page();
+        $page->setId('1e7e638f78864ec591ea54ec7016e146');
+        $page->setProperties([
+            'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('New title!')]),
+        ]);
+
+        $pageUpdated = $client->pages()->update($page);
+        $this->assertNotEmpty($pageUpdated->getProperties());
+    }
+
+    public function testUpdatePageSendsArchivedWhenExplicitlySetTrue(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertStringContainsString('PATCH', $method);
+            $this->assertStringContainsString('pages/1e7e638f78864ec591ea54ec7016e146', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertArrayHasKey('archived', $body);
+            $this->assertTrue($body['archived']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $page = new Page();
+        $page->setId('1e7e638f78864ec591ea54ec7016e146');
+        $page->setProperties([
+            'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('New title!')]),
+        ]);
+        $page->setArchived(true);
+
+        $pageUpdated = $client->pages()->update($page);
         $this->assertNotEmpty($pageUpdated->getProperties());
     }
 

--- a/tests/Resource/AbstractJsonSerializableTest.php
+++ b/tests/Resource/AbstractJsonSerializableTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource;
+
+use Brd6\NotionSdkPhp\Resource\AbstractJsonSerializable;
+use PHPUnit\Framework\TestCase;
+
+class AbstractJsonSerializableTest extends TestCase
+{
+    public function testToArrayStrictReturnsOnlyRequestedKeys(): void
+    {
+        $resource = $this->createResource('set');
+
+        $this->assertSame(['foo' => 'foo'], $resource->toArrayStrict(['foo']));
+    }
+
+    public function testToArrayStrictRespectsIgnoreEmptyValueFlag(): void
+    {
+        $resource = $this->createResource(null);
+
+        $this->assertSame([], $resource->toArrayStrict(['optional']));
+        $this->assertSame(['optional' => null], $resource->toArrayStrict(['optional'], false));
+    }
+
+    private function createResource(?string $optional): AbstractJsonSerializable
+    {
+        return new class ($optional) extends AbstractJsonSerializable {
+            protected string $foo = 'foo';
+            protected string $bar = 'bar';
+            protected ?string $optional;
+
+            public function __construct(?string $optional)
+            {
+                $this->optional = $optional;
+            }
+        };
+    }
+}

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -9,7 +9,10 @@ use Brd6\NotionSdkPhp\Resource\File\Emoji;
 use Brd6\NotionSdkPhp\Resource\File\External;
 use Brd6\NotionSdkPhp\Resource\File\Icon;
 use Brd6\NotionSdkPhp\Resource\Page;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\DatabaseIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\NumberPropertyValue;
+use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\TitlePropertyValue;
+use Brd6\NotionSdkPhp\Resource\RichText\Text;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -97,6 +100,51 @@ class PageTest extends TestCase
         $this->assertNotNull($icon->getIcon());
         $this->assertSame('book', $icon->getIcon()->getName());
         $this->assertSame('gray', $icon->getIcon()->getColor());
+    }
+
+    public function testPageIsArchivedReturnsFalseWhenUnset(): void
+    {
+        $page = new Page();
+
+        $this->assertFalse($page->isArchived());
+    }
+
+    public function testPageToArrayForCreateDoesNotIncludeArchivedWhenUnset(): void
+    {
+        $page = (new Page())
+            ->setParent((new DatabaseIdParent())->setDatabaseId('248104cd-477e-80fd-b757-e945d38000bd'))
+            ->setProperties([
+                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
+            ]);
+
+        $data = $page->toArrayForCreate();
+        $this->assertArrayNotHasKey('archived', $data);
+    }
+
+    public function testPageToArrayForCreateIncludesArchivedWhenExplicitlySet(): void
+    {
+        $page = (new Page())
+            ->setParent((new DatabaseIdParent())->setDatabaseId('248104cd-477e-80fd-b757-e945d38000bd'))
+            ->setProperties([
+                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
+            ])
+            ->setArchived(true);
+
+        $data = $page->toArrayForCreate();
+        $this->assertArrayHasKey('archived', $data);
+        $this->assertTrue($data['archived']);
+    }
+
+    public function testPageToArrayForUpdateIncludesArchivedFalseWhenUnset(): void
+    {
+        $page = (new Page())
+            ->setProperties([
+                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
+            ]);
+
+        $data = $page->toArrayForUpdate();
+        $this->assertArrayHasKey('archived', $data);
+        $this->assertFalse($data['archived']);
     }
 
     public function testPageProperties(): void

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -111,40 +111,44 @@ class PageTest extends TestCase
 
     public function testPageToArrayForCreateDoesNotIncludeArchivedWhenUnset(): void
     {
-        $page = (new Page())
-            ->setParent((new DatabaseIdParent())->setDatabaseId('248104cd-477e-80fd-b757-e945d38000bd'))
-            ->setProperties([
-                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
-            ]);
+        $page = $this->createPageForCreateSerialization();
 
         $data = $page->toArrayForCreate();
         $this->assertArrayNotHasKey('archived', $data);
     }
 
-    public function testPageToArrayForCreateIncludesArchivedWhenExplicitlySet(): void
+    /**
+     * @dataProvider archivedValuesProvider
+     */
+    public function testPageToArrayForCreateIncludesArchivedWhenExplicitlySet(bool $archived): void
     {
-        $page = (new Page())
-            ->setParent((new DatabaseIdParent())->setDatabaseId('248104cd-477e-80fd-b757-e945d38000bd'))
-            ->setProperties([
-                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
-            ])
-            ->setArchived(true);
+        $page = $this->createPageForCreateSerialization()
+            ->setArchived($archived);
 
         $data = $page->toArrayForCreate();
         $this->assertArrayHasKey('archived', $data);
-        $this->assertTrue($data['archived']);
+        $this->assertSame($archived, $data['archived']);
     }
 
-    public function testPageToArrayForUpdateIncludesArchivedFalseWhenUnset(): void
+    public function testPageToArrayForUpdateDoesNotIncludeArchivedWhenUnset(): void
     {
-        $page = (new Page())
-            ->setProperties([
-                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
-            ]);
+        $page = $this->createPageForUpdateSerialization();
+
+        $data = $page->toArrayForUpdate();
+        $this->assertArrayNotHasKey('archived', $data);
+    }
+
+    /**
+     * @dataProvider archivedValuesProvider
+     */
+    public function testPageToArrayForUpdateIncludesArchivedWhenExplicitlySet(bool $archived): void
+    {
+        $page = $this->createPageForUpdateSerialization()
+            ->setArchived($archived);
 
         $data = $page->toArrayForUpdate();
         $this->assertArrayHasKey('archived', $data);
-        $this->assertFalse($data['archived']);
+        $this->assertSame($archived, $data['archived']);
     }
 
     public function testPageProperties(): void
@@ -189,5 +193,33 @@ class PageTest extends TestCase
 
         $this->assertInstanceOf(NumberPropertyValue::class, $myNumberFloat);
         $this->assertEquals(42.42, $myNumberFloat->getNumber());
+    }
+
+    /**
+     * @return bool[][]
+     */
+    public static function archivedValuesProvider(): array
+    {
+        return [
+            [false],
+            [true],
+        ];
+    }
+
+    private function createPageForCreateSerialization(): Page
+    {
+        return (new Page())
+            ->setParent((new DatabaseIdParent())->setDatabaseId('248104cd-477e-80fd-b757-e945d38000bd'))
+            ->setProperties([
+                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
+            ]);
+    }
+
+    private function createPageForUpdateSerialization(): Page
+    {
+        return (new Page())
+            ->setProperties([
+                'title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test')]),
+            ]);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
  This PR fixes page creation payload serialization so `archived` is not sent by default, which resolves API validation failures on `pages()->create()`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #67

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
