### PR TITLE
fix(parent): support block_id page parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Add support for documented Notion `block_id` page parents so page and search hydration no longer throw `UnsupportedParentTypeException` for block-parent pages.
+
 ## 1.8.2 - 2026-03-27
 
 ### Fixed

--- a/src/Resource/Page/Parent/BlockIdParent.php
+++ b/src/Resource/Page/Parent/BlockIdParent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Page\Parent;
+
+class BlockIdParent extends AbstractParentProperty
+{
+    protected string $blockId = '';
+
+    public function __construct()
+    {
+        $this->type = 'block_id';
+    }
+
+    protected function initialize(): void
+    {
+        $this->blockId = (string) $this->getRawData()['block_id'];
+    }
+
+    public function getBlockId(): string
+    {
+        return $this->blockId;
+    }
+
+    public function setBlockId(string $blockId): self
+    {
+        $this->blockId = $blockId;
+
+        return $this;
+    }
+}

--- a/tests/Endpoint/SearchEndpointTest.php
+++ b/tests/Endpoint/SearchEndpointTest.php
@@ -8,6 +8,8 @@ use Brd6\NotionSdkPhp\Client;
 use Brd6\NotionSdkPhp\ClientOptions;
 use Brd6\NotionSdkPhp\Resource\DataSource;
 use Brd6\NotionSdkPhp\Resource\Database;
+use Brd6\NotionSdkPhp\Resource\Page;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\BlockIdParent;
 use Brd6\NotionSdkPhp\Resource\Pagination\PageOrDatabaseResults;
 use Brd6\NotionSdkPhp\Resource\Search\SearchRequest;
 use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
@@ -132,5 +134,38 @@ class SearchEndpointTest extends TestCase
         $this->assertInstanceOf(PageOrDatabaseResults::class, $results);
         $this->assertGreaterThan(0, count($results->getResults()));
         $this->assertInstanceOf(DataSource::class, $results->getResults()[0]);
+    }
+
+    public function testSearchWithPageBlockParentResponse(): void
+    {
+        $blockId = '7d50a184-5bbe-4d90-8f29-6bec57ed817b';
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString('search', $url);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_search_page_with_block_parent_200.json'),
+                [
+                    'http_code' => 200,
+                ],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        /** @var PageOrDatabaseResults $results */
+        $results = $client->search();
+
+        $this->assertInstanceOf(PageOrDatabaseResults::class, $results);
+        $this->assertGreaterThan(0, count($results->getResults()));
+
+        /** @var Page $resultPage */
+        $resultPage = $results->getResults()[0];
+        $parent = $resultPage->getParent();
+
+        $this->assertInstanceOf(Page::class, $resultPage);
+        $this->assertInstanceOf(BlockIdParent::class, $parent);
+        $this->assertSame($blockId, $parent->getBlockId());
     }
 }

--- a/tests/Fixtures/client_search_page_with_block_parent_200.json
+++ b/tests/Fixtures/client_search_page_with_block_parent_200.json
@@ -1,0 +1,56 @@
+{
+    "object": "list",
+    "results": [
+        {
+            "object": "page",
+            "id": "4a808e6e-8845-4d49-a447-fb2a4c460f6f",
+            "created_time": "2022-03-08T22:56:00.000Z",
+            "last_edited_time": "2022-03-24T15:24:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "7f03dda0-a132-49d7-b8b2-29c9ed1b1f0e"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "8dee9e49-7369-4a6d-a11f-7db625b2448c"
+            },
+            "cover": null,
+            "icon": null,
+            "parent": {
+                "type": "block_id",
+                "block_id": "7d50a184-5bbe-4d90-8f29-6bec57ed817b"
+            },
+            "archived": false,
+            "properties": {
+                "title": {
+                    "id": "title",
+                    "type": "title",
+                    "title": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Getting Started",
+                                "link": null
+                            },
+                            "annotations": {
+                                "bold": false,
+                                "italic": false,
+                                "strikethrough": false,
+                                "underline": false,
+                                "code": false,
+                                "color": "default"
+                            },
+                            "plain_text": "Getting Started",
+                            "href": null
+                        }
+                    ]
+                }
+            },
+            "url": "https://www.notion.so/Getting-Started-4a808e6e88454d49a447fb2a4c460f6f"
+        }
+    ],
+    "next_cursor": null,
+    "has_more": false,
+    "type": "page_or_database",
+    "page_or_database": {}
+}

--- a/tests/Resource/Page/Parent/BlockIdParentTest.php
+++ b/tests/Resource/Page/Parent/BlockIdParentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource\Page\Parent;
+
+use Brd6\NotionSdkPhp\Exception\UnsupportedParentTypeException;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\BlockIdParent;
+use Brd6\Test\NotionSdkPhp\TestCase;
+
+class BlockIdParentTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $blockId = '7d50a184-5bbe-4d90-8f29-6bec57ed817b';
+
+        $parent = (new BlockIdParent())
+            ->setBlockId($blockId);
+
+        $this->assertEquals(
+            [
+                'type' => 'block_id',
+                'block_id' => $blockId,
+            ],
+            $parent->toArray(),
+        );
+    }
+
+    public function testFromRawData(): void
+    {
+        $blockId = '7d50a184-5bbe-4d90-8f29-6bec57ed817b';
+
+        $parent = AbstractParentProperty::fromRawData([
+            'type' => 'block_id',
+            'block_id' => $blockId,
+        ]);
+
+        $this->assertInstanceOf(BlockIdParent::class, $parent);
+        $this->assertSame($blockId, $parent->getBlockId());
+    }
+
+    public function testUnsupportedParentTypeStillThrows(): void
+    {
+        $this->expectException(UnsupportedParentTypeException::class);
+
+        AbstractParentProperty::fromRawData([
+            'type' => 'unsupported_parent',
+        ]);
+    }
+}

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -9,6 +9,7 @@ use Brd6\NotionSdkPhp\Resource\File\Emoji;
 use Brd6\NotionSdkPhp\Resource\File\External;
 use Brd6\NotionSdkPhp\Resource\File\Icon;
 use Brd6\NotionSdkPhp\Resource\Page;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\BlockIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\DatabaseIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\NumberPropertyValue;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\TitlePropertyValue;
@@ -100,6 +101,29 @@ class PageTest extends TestCase
         $this->assertNotNull($icon->getIcon());
         $this->assertSame('book', $icon->getIcon()->getName());
         $this->assertSame('gray', $icon->getIcon()->getColor());
+    }
+
+    public function testPageWithBlockIdParent(): void
+    {
+        $blockId = '7d50a184-5bbe-4d90-8f29-6bec57ed817b';
+
+        /** @var array $rawData */
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+            true,
+        );
+        $rawData['parent'] = [
+            'type' => 'block_id',
+            'block_id' => $blockId,
+        ];
+
+        /** @var Page $page */
+        $page = Page::fromRawData($rawData);
+
+        $parent = $page->getParent();
+
+        $this->assertInstanceOf(BlockIdParent::class, $parent);
+        $this->assertSame($blockId, $parent->getBlockId());
     }
 
     public function testPageIsArchivedReturnsFalseWhenUnset(): void


### PR DESCRIPTION
## Description
Adds support for Notion page parents with `type: "block_id"`.

## Motivation and context
Notion can return pages whose parent is a block. The SDK previously threw `UnsupportedParentTypeException` while hydrating those pages.

## How has this been tested?
Unit tests and new fixture.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
