### PR TITLE
feat(blocks): support heading 4/5/6 blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.9.0 - 2026-05-28
+
+### Added
+
+- Add support for Notion `heading_4`, `heading_5`, and `heading_6` blocks through `Heading4Block`, `Heading5Block`, and `Heading6Block`.
+
 ## 1.8.3 - 2026-05-10
 
 ### Fixed

--- a/src/Resource/Block/Heading4Block.php
+++ b/src/Resource/Block/Heading4Block.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
+
+class Heading4Block extends AbstractHeadingBlock
+{
+    protected ?HeadingProperty $heading4 = null;
+
+    public function getHeading4(): ?HeadingProperty
+    {
+        return $this->heading4;
+    }
+
+    public function setHeading4(?HeadingProperty $heading): self
+    {
+        $this->heading4 = $heading;
+
+        return $this;
+    }
+}

--- a/src/Resource/Block/Heading5Block.php
+++ b/src/Resource/Block/Heading5Block.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
+
+class Heading5Block extends AbstractHeadingBlock
+{
+    protected ?HeadingProperty $heading5 = null;
+
+    public function getHeading5(): ?HeadingProperty
+    {
+        return $this->heading5;
+    }
+
+    public function setHeading5(?HeadingProperty $heading): self
+    {
+        $this->heading5 = $heading;
+
+        return $this;
+    }
+}

--- a/src/Resource/Block/Heading6Block.php
+++ b/src/Resource/Block/Heading6Block.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
+
+class Heading6Block extends AbstractHeadingBlock
+{
+    protected ?HeadingProperty $heading6 = null;
+
+    public function getHeading6(): ?HeadingProperty
+    {
+        return $this->heading6;
+    }
+
+    public function setHeading6(?HeadingProperty $heading): self
+    {
+        $this->heading6 = $heading;
+
+        return $this;
+    }
+}

--- a/tests/Resource/BlockTest.php
+++ b/tests/Resource/BlockTest.php
@@ -11,8 +11,15 @@ use Brd6\NotionSdkPhp\Resource\Block\CalloutBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ChildPageBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ColumnBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ColumnListBlock;
+use Brd6\NotionSdkPhp\Resource\Block\Heading1Block;
+use Brd6\NotionSdkPhp\Resource\Block\Heading2Block;
+use Brd6\NotionSdkPhp\Resource\Block\Heading3Block;
+use Brd6\NotionSdkPhp\Resource\Block\Heading4Block;
+use Brd6\NotionSdkPhp\Resource\Block\Heading5Block;
+use Brd6\NotionSdkPhp\Resource\Block\Heading6Block;
 use Brd6\NotionSdkPhp\Resource\Block\ParagraphBlock;
 use Brd6\NotionSdkPhp\Resource\Block\SyncedBlockBlock;
+use Brd6\NotionSdkPhp\Resource\Block\UnsupportedBlock;
 use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
 use Brd6\NotionSdkPhp\Resource\File\Emoji;
 use Brd6\NotionSdkPhp\Resource\Property\CalloutProperty;
@@ -50,6 +57,17 @@ class BlockTest extends TestCase
         AbstractBlock::fromRawData([
             'type' => 'invalid_type',
         ]);
+    }
+
+    public function testUnsupportedBlock(): void
+    {
+        $block = AbstractBlock::fromRawData([
+            'object' => 'block',
+            'type' => 'unsupported_block',
+        ]);
+
+        $this->assertInstanceOf(UnsupportedBlock::class, $block);
+        $this->assertEquals('unsupported_block', $block->getType());
     }
 
     public function testBlock(): void
@@ -110,30 +128,42 @@ class BlockTest extends TestCase
     public function testHeadingsBlock(): void
     {
         $headings = [
-            'heading_1',
-            'heading_2',
-            'heading_3',
+            'heading_1' => Heading1Block::class,
+            'heading_2' => Heading2Block::class,
+            'heading_3' => Heading3Block::class,
+            'heading_4' => Heading4Block::class,
+            'heading_5' => Heading5Block::class,
+            'heading_6' => Heading6Block::class,
         ];
 
-        foreach ($headings as $heading) {
+        foreach ($headings as $heading => $blockClass) {
             $rawContent = (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_heading1_200.json');
 
             $rawContent = str_replace('heading_1', $heading, $rawContent);
+            $rawData = (array) json_decode($rawContent, true);
 
             $block = AbstractBlock::fromRawData(
-                (array) json_decode(
-                    $rawContent,
-                    true,
-                ),
+                $rawData,
             );
 
+            $blockData = $block->toArray();
             $typeFormatted = StringHelper::snakeCaseToCamelCase($block->getType());
             $getterMethodName = "get$typeFormatted";
 
+            $this->assertInstanceOf($blockClass, $block);
             $this->assertEquals($heading, $block->getType());
             $this->assertNotNull($block->$getterMethodName());
             $this->assertInstanceOf(HeadingProperty::class, $block->$getterMethodName());
             $this->assertGreaterThan(0, count($block->$getterMethodName()->getRichText()));
+            $this->assertArrayHasKey($heading, $blockData);
+            $this->assertSame($rawData[$heading]['color'], $blockData[$heading]['color']);
+            $this->assertSame($rawData[$heading]['rich_text'][0]['type'], $blockData[$heading]['rich_text'][0]['type']);
+            $this->assertEquals($rawData[$heading]['rich_text'][0]['annotations'], $blockData[$heading]['rich_text'][0]['annotations']);
+            $this->assertSame($rawData[$heading]['rich_text'][0]['plain_text'], $blockData[$heading]['rich_text'][0]['plain_text']);
+            $this->assertSame(
+                $rawData[$heading]['rich_text'][0]['text']['content'],
+                $blockData[$heading]['rich_text'][0]['text']['content'],
+            );
 
             $richText = $block->$getterMethodName()->getRichText()[0];
 


### PR DESCRIPTION
## Description
Add concrete block models for Notion `heading_4`, `heading_5`, and `heading_6` payloads.

The new classes reuse the existing generic heading hydration and serialization path, so higher heading levels now preserve rich text instead of resolving to `UnsupportedBlock`.

## Motivation and context
Notion can return higher heading levels. Without matching block classes, those payloads fall back to `UnsupportedBlock`, which does not hydrate the heading property and loses rich text for consumers.

## How has this been tested?
- `composer test`
- `composer dev:lint:syntax`
- `composer dev:lint:style`
- `composer dev:analyze:all`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
