### PR TITLE
fix(blocks): serialize only creatable fields for children payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Blocks sent as children in `blocks()->children()->append()` and `pages()->create()` now serialize only creatable fields (`object`, `type`, and the block's own property) via `AbstractBlock::toArrayForCreate()`. The Notion API rejects payloads carrying read-only fields such as `archived` with a validation error.
+- Nested blocks set with `setChildren()` now serialize inside the block's type property — the only shape the Notion API accepts — and recursively emit only creatable fields, so appending a block with nested children works instead of failing validation.
 
 ## 1.9.0 - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Default request headers (`Notion-Version`, `Content-Type`, `User-Agent`) are now applied only when a request does not already set them, so a per-request `Content-Type` takes precedence over the JSON default. Requests that set no headers are unchanged.
 
+### Fixed
+
+- Blocks sent as children in `blocks()->children()->append()` and `pages()->create()` now serialize only creatable fields (`object`, `type`, and the block's own property) via `AbstractBlock::toArrayForCreate()`. The Notion API rejects payloads carrying read-only fields such as `archived` with a validation error.
+
 ## 1.9.0 - 2026-05-28
 
 ### Added

--- a/src/Endpoint/BlocksChildrenEndpoint.php
+++ b/src/Endpoint/BlocksChildrenEndpoint.php
@@ -57,7 +57,7 @@ class BlocksChildrenEndpoint extends AbstractEndpoint
      */
     public function append(string $blockId, array $children): AbstractPaginationResults
     {
-        $childrenData = array_map(fn (AbstractBlock $block) => $block->toArray(), $children);
+        $childrenData = array_map(fn (AbstractBlock $block) => $block->toArrayForCreate(), $children);
 
         $requestParameters = (new RequestParameters())
             ->setPath("blocks/$blockId/children")

--- a/src/Endpoint/PagesEndpoint.php
+++ b/src/Endpoint/PagesEndpoint.php
@@ -66,7 +66,7 @@ class PagesEndpoint extends AbstractEndpoint
      */
     public function create(Page $page, array $children = []): Page
     {
-        $childrenData = array_map(fn (AbstractBlock $block) => $block->toArray(), $children);
+        $childrenData = array_map(fn (AbstractBlock $block) => $block->toArrayForCreate(), $children);
 
         $data = array_merge($page->toArrayForCreate(), ['children' => $childrenData]);
 

--- a/src/Resource/Block/AbstractBlock.php
+++ b/src/Resource/Block/AbstractBlock.php
@@ -17,6 +17,7 @@ use ReflectionClass;
 
 use function array_map;
 use function class_exists;
+use function count;
 use function preg_replace;
 
 abstract class AbstractBlock extends AbstractResource
@@ -245,7 +246,16 @@ abstract class AbstractBlock extends AbstractResource
 
     public function toArrayForCreate(): array
     {
-        return $this->toArrayStrict(['object', 'type', $this->getType()]);
+        $data = $this->toArrayStrict(['object', 'type', $this->getType()]);
+
+        if (count($this->children) > 0) {
+            $data[$this->getType()]['children'] = array_map(
+                fn (AbstractBlock $child) => $child->toArrayForCreate(),
+                $this->children,
+            );
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Resource/Block/AbstractBlock.php
+++ b/src/Resource/Block/AbstractBlock.php
@@ -243,6 +243,11 @@ abstract class AbstractBlock extends AbstractResource
         return $this->getProperty() !== null ? $this->getProperty()->toArray() : [];
     }
 
+    public function toArrayForCreate(): array
+    {
+        return $this->toArrayStrict(['object', 'type', $this->getType()]);
+    }
+
     /**
      * @return array|AbstractBlock[]
      */

--- a/src/Resource/Block/AbstractBlock.php
+++ b/src/Resource/Block/AbstractBlock.php
@@ -249,10 +249,12 @@ abstract class AbstractBlock extends AbstractResource
         $data = $this->toArrayStrict(['object', 'type', $this->getType()]);
 
         if (count($this->children) > 0) {
-            $data[$this->getType()]['children'] = array_map(
+            $property = (array) ($data[$this->getType()] ?? []);
+            $property['children'] = array_map(
                 fn (AbstractBlock $child) => $child->toArrayForCreate(),
                 $this->children,
             );
+            $data[$this->getType()] = $property;
         }
 
         return $data;

--- a/tests/Endpoint/BlocksEndpointTest.php
+++ b/tests/Endpoint/BlocksEndpointTest.php
@@ -16,6 +16,7 @@ use Brd6\NotionSdkPhp\Resource\Pagination\BlockResults;
 use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
 use Brd6\NotionSdkPhp\Resource\Property\ChildPageProperty;
 use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
+use Brd6\NotionSdkPhp\Resource\Property\ParagraphProperty;
 use Brd6\NotionSdkPhp\Resource\RichText\Text;
 use Brd6\NotionSdkPhp\Resource\UserInterface;
 use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
@@ -267,6 +268,13 @@ class BlocksEndpointTest extends TestCase
                 $this->assertArrayHasKey('heading_3', $body['children'][0]);
                 $this->assertArrayNotHasKey('archived', $body['children'][0]);
                 $this->assertArrayNotHasKey('has_children', $body['children'][0]);
+                $this->assertArrayNotHasKey('children', $body['children'][0]);
+                $this->assertArrayHasKey('children', $body['children'][0]['heading_3']);
+                $this->assertEquals(
+                    'Nested paragraph',
+                    $body['children'][0]['heading_3']['children'][0]['paragraph']['rich_text'][0]['text']['content'],
+                );
+                $this->assertArrayNotHasKey('archived', $body['children'][0]['heading_3']['children'][0]);
                 $this->assertArrayHasKey('rich_text', $body['children'][0]['heading_3']);
                 $this->assertNotEmpty($body['children'][0]['heading_3']['rich_text']);
                 $this->assertStringContainsString(
@@ -296,6 +304,12 @@ class BlocksEndpointTest extends TestCase
         $heading3Property = new HeadingProperty();
         $heading3Property->setRichText([$richText]);
         $heading3->setHeading3($heading3Property);
+
+        $nestedParagraph = new ParagraphBlock();
+        $nestedParagraphProperty = new ParagraphProperty();
+        $nestedParagraphProperty->setRichText([Text::fromContent('Nested paragraph')]);
+        $nestedParagraph->setParagraph($nestedParagraphProperty);
+        $heading3->setChildren([$nestedParagraph]);
 
         /** @var BlockResults $paginationResponse */
         $paginationResponse = $client

--- a/tests/Endpoint/BlocksEndpointTest.php
+++ b/tests/Endpoint/BlocksEndpointTest.php
@@ -265,6 +265,8 @@ class BlocksEndpointTest extends TestCase
                 $this->assertArrayHasKey('object', $body['children'][0]);
                 $this->assertArrayHasKey('type', $body['children'][0]);
                 $this->assertArrayHasKey('heading_3', $body['children'][0]);
+                $this->assertArrayNotHasKey('archived', $body['children'][0]);
+                $this->assertArrayNotHasKey('has_children', $body['children'][0]);
                 $this->assertArrayHasKey('rich_text', $body['children'][0]['heading_3']);
                 $this->assertNotEmpty($body['children'][0]['heading_3']['rich_text']);
                 $this->assertStringContainsString(

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -135,6 +135,8 @@ class PagesEndpointTest extends TestCase
 
             $this->assertArrayHasKey('icon', $body);
             $this->assertArrayHasKey('children', $body);
+            $this->assertArrayNotHasKey('archived', $body['children'][0]);
+            $this->assertArrayNotHasKey('has_children', $body['children'][0]);
             $this->assertArrayHasKey('properties', $body);
             $this->assertNotEmpty($body['properties']['title']);
             $this->assertStringContainsString(


### PR DESCRIPTION
## Description

Blocks passed as children to `blocks()->children()->append()` and `pages()->create()` were serialized with their full state, including read-only fields (`archived`, `has_children`). The Notion API rejects such payloads with `validation_error: body.children[0].archived should be not present`, which makes both write paths fail for every block type.

`AbstractBlock` gains `toArrayForCreate()`, which serializes only the creatable fields — `object`, `type`, and the block's own type property — and both call sites now use it. This mirrors the existing `toArrayForCreate()`/`toArrayForUpdate()` accepted-keys pattern on `Page` and `Database`. Nested blocks set with `setChildren()` are serialized recursively inside the block's type property, the only placement the API accepts (the previous top-level `children` key was also rejected).

## Motivation and context

Appending any block (for example a heading or paragraph) through the SDK currently fails against the live Notion API. The read-only fields were always sent; the API now enforces their absence.

## How has this been tested?

- Extended the existing `testAppendBlockChildren` and `testCreatePage` cases to assert `archived` and `has_children` are absent from serialized children (both failed before the fix, pass after).
- Verified against the live Notion API: appending a paragraph block previously returned the validation error above and now succeeds, and appending a heading with a nested paragraph set via `setChildren()` creates the nested block (`has_children: true`, child read back). Both payload placements for nested children were tested live: top-level `children` is rejected, type-property placement is accepted.
- Full suite green (135 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
