### PR TITLE
feat(file-uploads): support the Notion File Upload API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add per-request headers and raw (non-JSON) request bodies to `RequestParameters`, unblocking `multipart/form-data` endpoints such as the Notion File Upload API.
 - Add `php-http/multipart-stream-builder` as a dependency for building multipart request bodies.
-- Add support for the Notion File Upload API via `$notion->fileUploads()`: create, send (`multipart/form-data`), complete, retrieve, and list file uploads.
+- Add support for the Notion File Upload API via `$notion->fileUploads()`: a one-call `upload()` for the common case, plus create, send/sendPart (`multipart/form-data`), complete, retrieve, and list.
 - Add the `file_upload` file-object type so blocks referencing uploaded files hydrate instead of throwing `UnsupportedFileTypeException`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add per-request headers and raw (non-JSON) request bodies to `RequestParameters`, unblocking `multipart/form-data` endpoints such as the Notion File Upload API.
 - Add `php-http/multipart-stream-builder` as a dependency for building multipart request bodies.
+- Add support for the Notion File Upload API via `$notion->fileUploads()`: create, send (`multipart/form-data`), complete, retrieve, and list file uploads.
+- Add the `file_upload` file-object type so blocks referencing uploaded files hydrate instead of throwing `UnsupportedFileTypeException`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -102,22 +102,28 @@ If you use Notion API version `2025-09-03` or newer, the SDK supports data sourc
 
 ### File uploads
 
-The SDK supports the [Notion File Upload API](https://developers.notion.com/reference/create-a-file-upload) via `$notion->fileUploads()`: create a file upload, send its contents as `multipart/form-data`, then reference the upload from a block, page icon, or cover:
+The SDK supports the [Notion File Upload API](https://developers.notion.com/reference/create-a-file-upload) via `$notion->fileUploads()`. Uploading a file takes one call — Notion derives the content type from the filename:
+
+```php
+$fileUpload = $notion->fileUploads()->upload($contents, 'image.png');
+```
+
+The uploaded file can then be referenced from a block, page icon, or cover. For larger files and imports, the underlying operations are exposed directly:
 
 ```php
 use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadRequest;
 
-$fileUpload = $notion->fileUploads()->create(
-    (new FileUploadRequest())
-        ->setMode(FileUploadRequest::MODE_SINGLE_PART)
-        ->setFilename('image.png')
-        ->setContentType('image/png'),
-);
+// import from a public HTTPS URL
+$fileUpload = $notion->fileUploads()->create(FileUploadRequest::externalUrl('https://example.com/image.png'));
 
-$fileUpload = $notion->fileUploads()->send($fileUpload->getId(), $contents, 'image.png', 'image/png');
+// multi-part upload (paid workspaces): create, send each part, then complete
+$fileUpload = $notion->fileUploads()->create(FileUploadRequest::multiPart(2, 'large.txt'));
+$notion->fileUploads()->sendPart($fileUpload->getId(), $firstChunk, 1, 'large.txt');
+$notion->fileUploads()->sendPart($fileUpload->getId(), $secondChunk, 2, 'large.txt');
+$fileUpload = $notion->fileUploads()->complete($fileUpload->getId());
 ```
 
-`retrieve()` and `list()` expose upload status, `complete()` finalizes a multi-part upload (send each part with a `$partNumber`), and `FileUploadRequest::MODE_EXTERNAL_URL` imports a file from a public HTTPS URL. See [examples/09-file-uploads-api-smoke](examples/09-file-uploads-api-smoke/) for the full flow, including attaching the upload to a page as an image block.
+`retrieve()` and `list()` expose upload status. See [examples/09-file-uploads-api-smoke](examples/09-file-uploads-api-smoke/) for the full flow, including attaching the upload to a page as an image block.
 
 ### Handling errors
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ $myPage = $notion->databases()->query('897e5a76-ae52-4b48-9fdf-e71f5945d1af', $d
 
 If you use Notion API version `2025-09-03` or newer, the SDK supports data source endpoints via `$notion->dataSources()`, and page creation with `data_source_id` parents. When creating a database with this API version, `databases()->create()` automatically maps `properties` to the required `initial_data_source` payload.
 
+### File uploads
+
+The SDK supports the [Notion File Upload API](https://developers.notion.com/reference/create-a-file-upload) via `$notion->fileUploads()`: create a file upload, send its contents as `multipart/form-data`, then reference the upload from a block, page icon, or cover:
+
+```php
+use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadRequest;
+
+$fileUpload = $notion->fileUploads()->create(
+    (new FileUploadRequest())
+        ->setMode(FileUploadRequest::MODE_SINGLE_PART)
+        ->setFilename('image.png')
+        ->setContentType('image/png'),
+);
+
+$fileUpload = $notion->fileUploads()->send($fileUpload->getId(), $contents, 'image.png', 'image/png');
+```
+
+`retrieve()` and `list()` expose upload status, `complete()` finalizes a multi-part upload (send each part with a `$partNumber`), and `FileUploadRequest::MODE_EXTERNAL_URL` imports a file from a public HTTPS URL. See [examples/09-file-uploads-api-smoke](examples/09-file-uploads-api-smoke/) for the full flow, including attaching the upload to a page as an image block.
+
 ### Handling errors
 
 If the API returns an unsuccessful response, an `ApiResponseException` will be thrown.

--- a/examples/09-file-uploads-api-smoke/README.md
+++ b/examples/09-file-uploads-api-smoke/README.md
@@ -1,11 +1,12 @@
 # File Uploads API Integration Example
 
-This example runs Notion File Upload API integration checks using the SDK's raw request support (per-request headers and raw bodies). It validates the full upload flow directly against your workspace:
+This example runs Notion File Upload API integration checks using the SDK's `fileUploads()` endpoint. It validates the full upload flow directly against your workspace:
 
-- create a file upload (`POST /v1/file_uploads`)
-- send the file contents as `multipart/form-data` (`POST /v1/file_uploads/{id}/send`)
-- retrieve the file upload and verify its status is `uploaded`
-- attach the uploaded image to a page as an image block
+- create a file upload (`fileUploads()->create()`)
+- send the file contents as `multipart/form-data` (`fileUploads()->send()`)
+- retrieve the file upload and verify its status is `uploaded` (`fileUploads()->retrieve()`)
+- attach the uploaded image to a page as an image block (`blocks()->children()->append()`)
+- list recent uploads (`fileUploads()->list()`)
 
 It is intended for live API validation and fixture discovery without touching the test fixtures in this repository.
 
@@ -49,10 +50,11 @@ File contents sent (status: uploaded)
 File upload verified (status: uploaded)
 Attaching the uploaded image to the page...
 Image block created: <block-id>
+Listing recent uploads...
+Uploads found: <count>
 Done. Check the page in Notion to see the uploaded image.
 ```
 
 ## Notes
 
-- The multipart request is built with `php-http/multipart-stream-builder`, which the SDK already depends on, and sent through `Client::request()` using `RequestParameters::setHeaders()` and `RequestParameters::setRawBody()`.
-- Uploaded files count against your workspace storage. Free workspaces are limited to 5 MiB per file.
+- Uploaded files count against your workspace storage. Free workspaces are limited to 5 MiB per file, and multi-part uploads (`FileUploadRequest::MODE_MULTI_PART`) require a paid plan.

--- a/examples/09-file-uploads-api-smoke/README.md
+++ b/examples/09-file-uploads-api-smoke/README.md
@@ -2,8 +2,7 @@
 
 This example runs Notion File Upload API integration checks using the SDK's `fileUploads()` endpoint. It validates the full upload flow directly against your workspace:
 
-- create a file upload (`fileUploads()->create()`)
-- send the file contents as `multipart/form-data` (`fileUploads()->send()`)
+- upload a file in one call — create + multipart send (`fileUploads()->upload()`)
 - retrieve the file upload and verify its status is `uploaded` (`fileUploads()->retrieve()`)
 - attach the uploaded image to a page as an image block (`blocks()->children()->append()`)
 - list recent uploads (`fileUploads()->list()`)
@@ -43,10 +42,8 @@ php index.php
 The script uploads a small PNG embedded in the example (no file on disk needed) and appends it to the configured page as an image block. Expected output:
 
 ```text
-Creating file upload...
-File upload created: <id> (status: pending)
-Sending file contents as multipart/form-data...
-File contents sent (status: uploaded)
+Uploading sample.png...
+File uploaded: <id> (status: uploaded)
 File upload verified (status: uploaded)
 Attaching the uploaded image to the page...
 Image block created: <block-id>

--- a/examples/09-file-uploads-api-smoke/index.php
+++ b/examples/09-file-uploads-api-smoke/index.php
@@ -10,7 +10,6 @@ use Brd6\NotionSdkPhp\Exception\ApiResponseException;
 use Brd6\NotionSdkPhp\Resource\Block\ImageBlock;
 use Brd6\NotionSdkPhp\Resource\File\FileUpload as FileUploadFile;
 use Brd6\NotionSdkPhp\Resource\FileUpload;
-use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadRequest;
 use Brd6\NotionSdkPhp\Resource\Property\FileUploadProperty;
 use Dotenv\Dotenv;
 
@@ -70,18 +69,9 @@ function main(): void
     $contents = (string) base64_decode(SAMPLE_PNG_BASE64, true);
 
     try {
-        echo "Creating file upload...\n";
-        $fileUpload = $notion->fileUploads()->create(
-            (new FileUploadRequest())
-                ->setMode(FileUploadRequest::MODE_SINGLE_PART)
-                ->setFilename($filename)
-                ->setContentType('image/png'),
-        );
-        echo "File upload created: {$fileUpload->getId()} (status: {$fileUpload->getStatus()})\n";
-
-        echo "Sending file contents as multipart/form-data...\n";
-        $fileUpload = $notion->fileUploads()->send($fileUpload->getId(), $contents, $filename, 'image/png');
-        echo "File contents sent (status: {$fileUpload->getStatus()})\n";
+        echo "Uploading {$filename}...\n";
+        $fileUpload = $notion->fileUploads()->upload($contents, $filename);
+        echo "File uploaded: {$fileUpload->getId()} (status: {$fileUpload->getStatus()})\n";
 
         $fileUpload = $notion->fileUploads()->retrieve($fileUpload->getId());
         if ($fileUpload->getStatus() !== FileUpload::STATUS_UPLOADED) {

--- a/examples/09-file-uploads-api-smoke/index.php
+++ b/examples/09-file-uploads-api-smoke/index.php
@@ -7,9 +7,12 @@ require_once __DIR__ . '/vendor/autoload.php';
 use Brd6\NotionSdkPhp\Client;
 use Brd6\NotionSdkPhp\ClientOptions;
 use Brd6\NotionSdkPhp\Exception\ApiResponseException;
-use Brd6\NotionSdkPhp\RequestParameters;
+use Brd6\NotionSdkPhp\Resource\Block\ImageBlock;
+use Brd6\NotionSdkPhp\Resource\File\FileUpload as FileUploadFile;
+use Brd6\NotionSdkPhp\Resource\FileUpload;
+use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadRequest;
+use Brd6\NotionSdkPhp\Resource\Property\FileUploadProperty;
 use Dotenv\Dotenv;
-use Http\Message\MultipartStream\MultipartStreamBuilder;
 
 // 240x120 labelled PNG so the example needs no file on disk and the block is visible on the page.
 const SAMPLE_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAPAAAAB4CAIAAABD1OhwAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAB/ElEQVR42u3YMW7CMABA0VJxDSY4JhsckwkuwhApch3bMTYtSfOeOlREcUz4dU12x8v9C/6Lb7cAQYOgQdAgaAQNggZBg6BB0AgaBA2CBkGDoBE0CBoEDYIGQSNoEDQIGgQNgkbQIGgQNAgaBI2gQdAgaBA0CBpBg6BB0CBoBA2CBkGDoEHQCBoEDYIGQYOgETQIGgQNggZBI+gtu50Pt/NhmfN579yW9k4F7YPkh71bMHW6PtwEQX9glR3iG9faKMRwDR4PhS+OIyTPmmZdGLAwjfL8c39INaMl599wo5KXa35fthy9WZ+uj+FeJ2ONDo2vRL/PLs+5AcvTmI1s/AlPDI/mRqusuWaGbYeWaXe83Ne+QueWouShmhpmT6+8Vq6A5FmVV0/+lyjUVjPDtntoy2EvHncWVdjTin3/pp9yLCT33JajMl8ParYSdG5LmttgzJbx0oCV+6XCJmF6rf6m2yb/xrdsy9HbdBhN9EnkjhaegZQH7JxeNGZ4dHYvPnxvq7ziq5Nf3VOOFX8ppPnb8++dZcsBVmiwQiNoEDQIGgQNgkbQIGgQNAgaBI2gQdAgaBA0CBpBg6BB0CBoBA2CBkGDoEHQCBoEDYIGQYOgETQIGgQNggZBI2gQNAgaBA2CRtAgaBA0CBoEjaBB0CBoEDQIGkGDoOHPPAGafD74akpkogAAAABJRU5ErkJggg==';
@@ -48,69 +51,12 @@ function createNotionClient(): Client
     return new Client($options);
 }
 
-function createFileUpload(Client $notion, string $filename): array
+function buildImageBlock(string $fileUploadId): ImageBlock
 {
-    $parameters = (new RequestParameters())
-        ->setPath('file_uploads')
-        ->setMethod('POST')
-        ->setBody([
-            'mode' => 'single_part',
-            'filename' => $filename,
-            'content_type' => 'image/png',
-        ]);
+    $image = new FileUploadFile();
+    $image->setFileUpload((new FileUploadProperty())->setId($fileUploadId));
 
-    return $notion->request($parameters);
-}
-
-function sendFileUpload(Client $notion, string $fileUploadId, string $contents, string $filename): array
-{
-    $builder = new MultipartStreamBuilder();
-    $builder->addResource('file', $contents, [
-        'filename' => $filename,
-        'headers' => ['Content-Type' => 'image/png'],
-    ]);
-
-    $parameters = (new RequestParameters())
-        ->setPath("file_uploads/{$fileUploadId}/send")
-        ->setMethod('POST')
-        ->setHeaders([
-            'Content-Type' => 'multipart/form-data; boundary="' . $builder->getBoundary() . '"',
-        ])
-        ->setRawBody((string) $builder->build());
-
-    return $notion->request($parameters);
-}
-
-function retrieveFileUpload(Client $notion, string $fileUploadId): array
-{
-    $parameters = (new RequestParameters())
-        ->setPath("file_uploads/{$fileUploadId}")
-        ->setMethod('GET');
-
-    return $notion->request($parameters);
-}
-
-function attachFileUploadToPage(Client $notion, string $pageId, string $fileUploadId): array
-{
-    $parameters = (new RequestParameters())
-        ->setPath("blocks/{$pageId}/children")
-        ->setMethod('PATCH')
-        ->setBody([
-            'children' => [
-                [
-                    'object' => 'block',
-                    'type' => 'image',
-                    'image' => [
-                        'type' => 'file_upload',
-                        'file_upload' => [
-                            'id' => $fileUploadId,
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-    return $notion->request($parameters);
+    return (new ImageBlock())->setImage($image);
 }
 
 function main(): void
@@ -125,24 +71,34 @@ function main(): void
 
     try {
         echo "Creating file upload...\n";
-        $fileUpload = createFileUpload($notion, $filename);
-        $fileUploadId = (string) $fileUpload['id'];
-        echo "File upload created: {$fileUploadId} (status: {$fileUpload['status']})\n";
+        $fileUpload = $notion->fileUploads()->create(
+            (new FileUploadRequest())
+                ->setMode(FileUploadRequest::MODE_SINGLE_PART)
+                ->setFilename($filename)
+                ->setContentType('image/png'),
+        );
+        echo "File upload created: {$fileUpload->getId()} (status: {$fileUpload->getStatus()})\n";
 
         echo "Sending file contents as multipart/form-data...\n";
-        $fileUpload = sendFileUpload($notion, $fileUploadId, $contents, $filename);
-        echo "File contents sent (status: {$fileUpload['status']})\n";
+        $fileUpload = $notion->fileUploads()->send($fileUpload->getId(), $contents, $filename, 'image/png');
+        echo "File contents sent (status: {$fileUpload->getStatus()})\n";
 
-        $fileUpload = retrieveFileUpload($notion, $fileUploadId);
-        if ($fileUpload['status'] !== 'uploaded') {
-            exitWithError("Unexpected file upload status: {$fileUpload['status']}");
+        $fileUpload = $notion->fileUploads()->retrieve($fileUpload->getId());
+        if ($fileUpload->getStatus() !== FileUpload::STATUS_UPLOADED) {
+            exitWithError("Unexpected file upload status: {$fileUpload->getStatus()}");
         }
-        echo "File upload verified (status: {$fileUpload['status']})\n";
+        echo "File upload verified (status: {$fileUpload->getStatus()})\n";
 
         echo "Attaching the uploaded image to the page...\n";
-        $result = attachFileUploadToPage($notion, $pageId, $fileUploadId);
-        $blockId = (string) $result['results'][0]['id'];
-        echo "Image block created: {$blockId}\n";
+        $results = $notion->blocks()->children()->append($pageId, [buildImageBlock($fileUpload->getId())]);
+
+        /** @var ImageBlock $block */
+        $block = $results->getResults()[0];
+        echo "Image block created: {$block->getId()}\n";
+
+        echo "Listing recent uploads...\n";
+        $uploads = $notion->fileUploads()->list();
+        echo "Uploads found: " . count($uploads->getResults()) . "\n";
 
         echo "Done. Check the page in Notion to see the uploaded image.\n";
     } catch (ApiResponseException $exception) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use Brd6\NotionSdkPhp\Endpoint\BlocksEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\CommentsEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\DataSourcesEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\DatabasesEndpoint;
+use Brd6\NotionSdkPhp\Endpoint\FileUploadsEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\PagesEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\SearchEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\UsersEndpoint;
@@ -51,6 +52,7 @@ class Client
     private PagesEndpoint $pagesEndpoint;
     private DatabasesEndpoint $databasesEndpoint;
     private DataSourcesEndpoint $dataSourcesEndpoint;
+    private FileUploadsEndpoint $fileUploadsEndpoint;
     private SearchEndpoint $searchEndpoint;
 
     public function __construct(?ClientOptions $options = null)
@@ -64,6 +66,7 @@ class Client
         $this->pagesEndpoint = new PagesEndpoint($this);
         $this->databasesEndpoint = new DatabasesEndpoint($this);
         $this->dataSourcesEndpoint = new DataSourcesEndpoint($this);
+        $this->fileUploadsEndpoint = new FileUploadsEndpoint($this);
         $this->searchEndpoint = new SearchEndpoint($this);
     }
 
@@ -205,6 +208,11 @@ class Client
     public function dataSources(): DataSourcesEndpoint
     {
         return $this->dataSourcesEndpoint;
+    }
+
+    public function fileUploads(): FileUploadsEndpoint
+    {
+        return $this->fileUploadsEndpoint;
     }
 
     public function getOptions(): ClientOptions

--- a/src/Endpoint/FileUploadsEndpoint.php
+++ b/src/Endpoint/FileUploadsEndpoint.php
@@ -33,12 +33,12 @@ class FileUploadsEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
-    public function create(FileUploadRequest $fileUploadRequest): FileUpload
+    public function create(?FileUploadRequest $fileUploadRequest = null): FileUpload
     {
         $requestParameters = (new RequestParameters())
             ->setPath('file_uploads')
             ->setMethod('POST')
-            ->setBody($fileUploadRequest->toArray());
+            ->setBody($fileUploadRequest ? $fileUploadRequest->toArray() : []);
 
         $rawData = $this->getClient()->request($requestParameters);
 
@@ -46,6 +46,24 @@ class FileUploadsEndpoint extends AbstractEndpoint
         $fileUpload = FileUpload::fromRawData($rawData);
 
         return $fileUpload;
+    }
+
+    /**
+     * Uploads a file in one call: creates a single-part file upload and sends its contents.
+     * The content type is derived by Notion from the filename extension when not provided.
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function upload(string $contents, string $filename, ?string $contentType = null): FileUpload
+    {
+        $fileUpload = $this->create(FileUploadRequest::singlePart($filename, $contentType));
+
+        return $this->send($fileUpload->getId(), $contents, $filename, $contentType);
     }
 
     /**
@@ -60,8 +78,45 @@ class FileUploadsEndpoint extends AbstractEndpoint
         string $fileUploadId,
         string $contents,
         string $filename,
-        ?string $contentType = null,
-        ?int $partNumber = null
+        ?string $contentType = null
+    ): FileUpload {
+        return $this->sendMultipart($fileUploadId, $contents, $filename, $contentType, null);
+    }
+
+    /**
+     * Sends one part of a multi-part file upload; call complete() after the last part.
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function sendPart(
+        string $fileUploadId,
+        string $contents,
+        int $partNumber,
+        string $filename,
+        ?string $contentType = null
+    ): FileUpload {
+        return $this->sendMultipart($fileUploadId, $contents, $filename, $contentType, $partNumber);
+    }
+
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    private function sendMultipart(
+        string $fileUploadId,
+        string $contents,
+        string $filename,
+        ?string $contentType,
+        ?int $partNumber
     ): FileUpload {
         $builder = new MultipartStreamBuilder();
         $builder->addResource('file', $contents, array_filter([

--- a/src/Endpoint/FileUploadsEndpoint.php
+++ b/src/Endpoint/FileUploadsEndpoint.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Exception\ApiResponseException;
+use Brd6\NotionSdkPhp\Exception\HttpResponseException;
+use Brd6\NotionSdkPhp\Exception\InvalidPaginationResponseException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceTypeException;
+use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedPaginationResponseTypeException;
+use Brd6\NotionSdkPhp\RequestParameters;
+use Brd6\NotionSdkPhp\Resource\FileUpload;
+use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadListRequest;
+use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadRequest;
+use Brd6\NotionSdkPhp\Resource\Pagination\AbstractPaginationResults;
+use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
+use Http\Client\Exception;
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+
+use function array_filter;
+use function array_merge;
+
+class FileUploadsEndpoint extends AbstractEndpoint
+{
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function create(FileUploadRequest $fileUploadRequest): FileUpload
+    {
+        $requestParameters = (new RequestParameters())
+            ->setPath('file_uploads')
+            ->setMethod('POST')
+            ->setBody($fileUploadRequest->toArray());
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var FileUpload $fileUpload */
+        $fileUpload = FileUpload::fromRawData($rawData);
+
+        return $fileUpload;
+    }
+
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function send(
+        string $fileUploadId,
+        string $contents,
+        string $filename,
+        ?string $contentType = null,
+        ?int $partNumber = null
+    ): FileUpload {
+        $builder = new MultipartStreamBuilder();
+        $builder->addResource('file', $contents, array_filter([
+            'filename' => $filename,
+            'headers' => $contentType !== null ? ['Content-Type' => $contentType] : null,
+        ]));
+
+        if ($partNumber !== null) {
+            $builder->addResource('part_number', (string) $partNumber);
+        }
+
+        $requestParameters = (new RequestParameters())
+            ->setPath("file_uploads/$fileUploadId/send")
+            ->setMethod('POST')
+            ->setHeaders([
+                'Content-Type' => 'multipart/form-data; boundary="' . $builder->getBoundary() . '"',
+            ])
+            ->setRawBody((string) $builder->build());
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var FileUpload $fileUpload */
+        $fileUpload = FileUpload::fromRawData($rawData);
+
+        return $fileUpload;
+    }
+
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function complete(string $fileUploadId): FileUpload
+    {
+        $requestParameters = (new RequestParameters())
+            ->setPath("file_uploads/$fileUploadId/complete")
+            ->setMethod('POST');
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var FileUpload $fileUpload */
+        $fileUpload = FileUpload::fromRawData($rawData);
+
+        return $fileUpload;
+    }
+
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function retrieve(string $fileUploadId): FileUpload
+    {
+        $requestParameters = (new RequestParameters())
+            ->setPath("file_uploads/$fileUploadId")
+            ->setMethod('GET');
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var FileUpload $fileUpload */
+        $fileUpload = FileUpload::fromRawData($rawData);
+
+        return $fileUpload;
+    }
+
+    /**
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidPaginationResponseException
+     * @throws RequestTimeoutException
+     * @throws UnsupportedPaginationResponseTypeException
+     */
+    public function list(
+        ?FileUploadListRequest $fileUploadListRequest = null,
+        ?PaginationRequest $paginationRequest = null
+    ): AbstractPaginationResults {
+        $paginationRequest = $paginationRequest ?? new PaginationRequest();
+
+        $query = array_merge(
+            $paginationRequest->toArray(),
+            $fileUploadListRequest ? $fileUploadListRequest->toArray() : [],
+        );
+
+        $requestParameters = (new RequestParameters())
+            ->setPath('file_uploads')
+            ->setQuery($query)
+            ->setMethod('GET');
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        return AbstractPaginationResults::fromRawData($rawData);
+    }
+}

--- a/src/Resource/File/FileUpload.php
+++ b/src/Resource/File/FileUpload.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\File;
+
+use Brd6\NotionSdkPhp\Resource\Property\FileUploadProperty;
+
+class FileUpload extends AbstractFile
+{
+    public const FILE_TYPE = 'file_upload';
+
+    protected ?FileUploadProperty $fileUpload = null;
+
+    public static function getFileType(): string
+    {
+        return self::FILE_TYPE;
+    }
+
+    protected function initialize(): void
+    {
+        $data = (array) $this->getRawData()[$this->getType()];
+        $this->fileUpload = FileUploadProperty::fromRawData($data);
+    }
+
+    public function getFileUpload(): ?FileUploadProperty
+    {
+        return $this->fileUpload;
+    }
+
+    public function setFileUpload(FileUploadProperty $fileUpload): self
+    {
+        $this->fileUpload = $fileUpload;
+
+        return $this;
+    }
+}

--- a/src/Resource/FileUpload.php
+++ b/src/Resource/FileUpload.php
@@ -30,6 +30,13 @@ class FileUpload extends AbstractResource
     protected array $fileImportResult = [];
     protected bool $inTrash = false;
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->object = self::RESOURCE_TYPE;
+    }
+
     public static function getResourceType(): string
     {
         return self::RESOURCE_TYPE;

--- a/src/Resource/FileUpload.php
+++ b/src/Resource/FileUpload.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource;
+
+use DateTimeImmutable;
+use Exception;
+
+class FileUpload extends AbstractResource
+{
+    public const RESOURCE_TYPE = 'file_upload';
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_UPLOADED = 'uploaded';
+    public const STATUS_EXPIRED = 'expired';
+    public const STATUS_FAILED = 'failed';
+
+    protected ?DateTimeImmutable $createdTime = null;
+    protected array $createdBy = [];
+    protected ?DateTimeImmutable $lastEditedTime = null;
+    protected ?DateTimeImmutable $expiryTime = null;
+    protected string $status = '';
+    protected ?string $filename = null;
+    protected ?string $contentType = null;
+    protected ?int $contentLength = null;
+    protected ?string $uploadUrl = null;
+    protected ?string $completeUrl = null;
+    protected array $numberOfParts = [];
+    protected array $fileImportResult = [];
+    protected bool $inTrash = false;
+
+    public static function getResourceType(): string
+    {
+        return self::RESOURCE_TYPE;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function initialize(): void
+    {
+        $rawData = $this->getRawData();
+
+        $this->createdTime = isset($rawData['created_time']) ?
+            new DateTimeImmutable((string) $rawData['created_time']) :
+            null;
+        $this->createdBy = (array) ($rawData['created_by'] ?? []);
+        $this->lastEditedTime = isset($rawData['last_edited_time']) ?
+            new DateTimeImmutable((string) $rawData['last_edited_time']) :
+            null;
+        $this->expiryTime = isset($rawData['expiry_time']) ?
+            new DateTimeImmutable((string) $rawData['expiry_time']) :
+            null;
+        $this->status = (string) ($rawData['status'] ?? '');
+        $this->filename = isset($rawData['filename']) ? (string) $rawData['filename'] : null;
+        $this->contentType = isset($rawData['content_type']) ? (string) $rawData['content_type'] : null;
+        $this->contentLength = isset($rawData['content_length']) ? (int) $rawData['content_length'] : null;
+        $this->uploadUrl = isset($rawData['upload_url']) ? (string) $rawData['upload_url'] : null;
+        $this->completeUrl = isset($rawData['complete_url']) ? (string) $rawData['complete_url'] : null;
+        $this->numberOfParts = (array) ($rawData['number_of_parts'] ?? []);
+        $this->fileImportResult = (array) ($rawData['file_import_result'] ?? []);
+        $this->inTrash = (bool) ($rawData['in_trash'] ?? $rawData['archived'] ?? false);
+    }
+
+    public function getCreatedTime(): ?DateTimeImmutable
+    {
+        return $this->createdTime;
+    }
+
+    public function setCreatedTime(?DateTimeImmutable $createdTime): self
+    {
+        $this->createdTime = $createdTime;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): array
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(array $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getLastEditedTime(): ?DateTimeImmutable
+    {
+        return $this->lastEditedTime;
+    }
+
+    public function setLastEditedTime(?DateTimeImmutable $lastEditedTime): self
+    {
+        $this->lastEditedTime = $lastEditedTime;
+
+        return $this;
+    }
+
+    public function getExpiryTime(): ?DateTimeImmutable
+    {
+        return $this->expiryTime;
+    }
+
+    public function setExpiryTime(?DateTimeImmutable $expiryTime): self
+    {
+        $this->expiryTime = $expiryTime;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getFilename(): ?string
+    {
+        return $this->filename;
+    }
+
+    public function setFilename(?string $filename): self
+    {
+        $this->filename = $filename;
+
+        return $this;
+    }
+
+    public function getContentType(): ?string
+    {
+        return $this->contentType;
+    }
+
+    public function setContentType(?string $contentType): self
+    {
+        $this->contentType = $contentType;
+
+        return $this;
+    }
+
+    public function getContentLength(): ?int
+    {
+        return $this->contentLength;
+    }
+
+    public function setContentLength(?int $contentLength): self
+    {
+        $this->contentLength = $contentLength;
+
+        return $this;
+    }
+
+    public function getUploadUrl(): ?string
+    {
+        return $this->uploadUrl;
+    }
+
+    public function setUploadUrl(?string $uploadUrl): self
+    {
+        $this->uploadUrl = $uploadUrl;
+
+        return $this;
+    }
+
+    public function getCompleteUrl(): ?string
+    {
+        return $this->completeUrl;
+    }
+
+    public function setCompleteUrl(?string $completeUrl): self
+    {
+        $this->completeUrl = $completeUrl;
+
+        return $this;
+    }
+
+    public function getNumberOfParts(): array
+    {
+        return $this->numberOfParts;
+    }
+
+    public function setNumberOfParts(array $numberOfParts): self
+    {
+        $this->numberOfParts = $numberOfParts;
+
+        return $this;
+    }
+
+    public function getFileImportResult(): array
+    {
+        return $this->fileImportResult;
+    }
+
+    public function setFileImportResult(array $fileImportResult): self
+    {
+        $this->fileImportResult = $fileImportResult;
+
+        return $this;
+    }
+
+    public function isInTrash(): bool
+    {
+        return $this->inTrash;
+    }
+
+    public function setInTrash(bool $inTrash): self
+    {
+        $this->inTrash = $inTrash;
+
+        return $this;
+    }
+}

--- a/src/Resource/FileUpload/FileUploadListRequest.php
+++ b/src/Resource/FileUpload/FileUploadListRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\FileUpload;
+
+use Brd6\NotionSdkPhp\Resource\AbstractJsonSerializable;
+
+class FileUploadListRequest extends AbstractJsonSerializable
+{
+    protected ?string $status = null;
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+}

--- a/src/Resource/FileUpload/FileUploadRequest.php
+++ b/src/Resource/FileUpload/FileUploadRequest.php
@@ -18,6 +18,31 @@ class FileUploadRequest extends AbstractJsonSerializable
     protected ?int $numberOfParts = null;
     protected ?string $externalUrl = null;
 
+    public static function singlePart(?string $filename = null, ?string $contentType = null): self
+    {
+        return (new self())
+            ->setMode(self::MODE_SINGLE_PART)
+            ->setFilename($filename)
+            ->setContentType($contentType);
+    }
+
+    public static function multiPart(int $numberOfParts, string $filename, ?string $contentType = null): self
+    {
+        return (new self())
+            ->setMode(self::MODE_MULTI_PART)
+            ->setNumberOfParts($numberOfParts)
+            ->setFilename($filename)
+            ->setContentType($contentType);
+    }
+
+    public static function externalUrl(string $externalUrl, ?string $filename = null): self
+    {
+        return (new self())
+            ->setMode(self::MODE_EXTERNAL_URL)
+            ->setExternalUrl($externalUrl)
+            ->setFilename($filename);
+    }
+
     public function getMode(): ?string
     {
         return $this->mode;

--- a/src/Resource/FileUpload/FileUploadRequest.php
+++ b/src/Resource/FileUpload/FileUploadRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\FileUpload;
+
+use Brd6\NotionSdkPhp\Resource\AbstractJsonSerializable;
+
+class FileUploadRequest extends AbstractJsonSerializable
+{
+    public const MODE_SINGLE_PART = 'single_part';
+    public const MODE_MULTI_PART = 'multi_part';
+    public const MODE_EXTERNAL_URL = 'external_url';
+
+    protected ?string $mode = null;
+    protected ?string $filename = null;
+    protected ?string $contentType = null;
+    protected ?int $numberOfParts = null;
+    protected ?string $externalUrl = null;
+
+    public function getMode(): ?string
+    {
+        return $this->mode;
+    }
+
+    public function setMode(?string $mode): self
+    {
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    public function getFilename(): ?string
+    {
+        return $this->filename;
+    }
+
+    public function setFilename(?string $filename): self
+    {
+        $this->filename = $filename;
+
+        return $this;
+    }
+
+    public function getContentType(): ?string
+    {
+        return $this->contentType;
+    }
+
+    public function setContentType(?string $contentType): self
+    {
+        $this->contentType = $contentType;
+
+        return $this;
+    }
+
+    public function getNumberOfParts(): ?int
+    {
+        return $this->numberOfParts;
+    }
+
+    public function setNumberOfParts(?int $numberOfParts): self
+    {
+        $this->numberOfParts = $numberOfParts;
+
+        return $this;
+    }
+
+    public function getExternalUrl(): ?string
+    {
+        return $this->externalUrl;
+    }
+
+    public function setExternalUrl(?string $externalUrl): self
+    {
+        $this->externalUrl = $externalUrl;
+
+        return $this;
+    }
+}

--- a/src/Resource/Pagination/FileUploadResults.php
+++ b/src/Resource/Pagination/FileUploadResults.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Pagination;
+
+use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceTypeException;
+use Brd6\NotionSdkPhp\Resource\FileUpload;
+
+use function array_map;
+
+class FileUploadResults extends AbstractPaginationResults
+{
+    /**
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     */
+    protected function initialize(): void
+    {
+        $this->results = isset($this->getRawData()['results']) ? array_map(
+            fn (array $resultRawData) => FileUpload::fromRawData($resultRawData),
+            (array) $this->getRawData()['results'],
+        ) : [];
+    }
+
+    /**
+     * @return FileUpload[]|array
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+}

--- a/src/Resource/Property/FileUploadProperty.php
+++ b/src/Resource/Property/FileUploadProperty.php
@@ -12,7 +12,7 @@ class FileUploadProperty extends AbstractProperty
     {
         $property = new self();
 
-        $property->id = (string) $rawData['id'];
+        $property->id = (string) ($rawData['id'] ?? '');
 
         return $property;
     }

--- a/src/Resource/Property/FileUploadProperty.php
+++ b/src/Resource/Property/FileUploadProperty.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Property;
+
+class FileUploadProperty extends AbstractProperty
+{
+    protected string $id = '';
+
+    public static function fromRawData(array $rawData): self
+    {
+        $property = new self();
+
+        $property->id = (string) $rawData['id'];
+
+        return $property;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId(string $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+}

--- a/tests/Endpoint/FileUploadsEndpointTest.php
+++ b/tests/Endpoint/FileUploadsEndpointTest.php
@@ -20,6 +20,7 @@ use DateTimeImmutable;
 use function count;
 use function file_get_contents;
 use function json_decode;
+use function strpos;
 
 class FileUploadsEndpointTest extends TestCase
 {
@@ -54,12 +55,8 @@ class FileUploadsEndpointTest extends TestCase
         });
 
         $client = new Client((new ClientOptions())->setHttpClient($httpClient));
-        $fileUploadRequest = (new FileUploadRequest())
-            ->setMode(FileUploadRequest::MODE_SINGLE_PART)
-            ->setFilename('sample.png')
-            ->setContentType('image/png');
 
-        $fileUpload = $client->fileUploads()->create($fileUploadRequest);
+        $fileUpload = $client->fileUploads()->create(FileUploadRequest::singlePart('sample.png', 'image/png'));
 
         $this->assertNotEmpty($fileUpload->getId());
         $this->assertEquals(FileUpload::STATUS_PENDING, $fileUpload->getStatus());
@@ -84,12 +81,10 @@ class FileUploadsEndpointTest extends TestCase
         });
 
         $client = new Client((new ClientOptions())->setHttpClient($httpClient));
-        $fileUploadRequest = (new FileUploadRequest())
-            ->setMode(FileUploadRequest::MODE_EXTERNAL_URL)
-            ->setFilename('image.png')
-            ->setExternalUrl('https://example.com/image.png');
 
-        $fileUpload = $client->fileUploads()->create($fileUploadRequest);
+        $fileUpload = $client->fileUploads()->create(
+            FileUploadRequest::externalUrl('https://example.com/image.png', 'image.png'),
+        );
 
         $this->assertEquals(FileUpload::STATUS_PENDING, $fileUpload->getStatus());
     }
@@ -109,16 +104,70 @@ class FileUploadsEndpointTest extends TestCase
         });
 
         $client = new Client((new ClientOptions())->setHttpClient($httpClient));
-        $fileUploadRequest = (new FileUploadRequest())
-            ->setMode(FileUploadRequest::MODE_MULTI_PART)
-            ->setFilename('sample-large.txt')
-            ->setContentType('text/plain')
-            ->setNumberOfParts(2);
 
-        $fileUpload = $client->fileUploads()->create($fileUploadRequest);
+        $fileUpload = $client->fileUploads()->create(
+            FileUploadRequest::multiPart(2, 'sample-large.txt', 'text/plain'),
+        );
 
         $this->assertEquals(['total' => 2, 'sent' => 0], $fileUpload->getNumberOfParts());
         $this->assertNotEmpty($fileUpload->getCompleteUrl());
+    }
+
+    public function testCreateFileUploadWithoutRequest(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertEquals('', $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_create_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $fileUpload = $client->fileUploads()->create();
+
+        $this->assertEquals(FileUpload::STATUS_PENDING, $fileUpload->getStatus());
+    }
+
+    public function testUploadFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+
+            if (strpos($url, '/send') !== false) {
+                $this->assertStringStartsWith(
+                    'multipart/form-data; boundary=',
+                    $options['headers']['Content-Type'][0],
+                );
+                $this->assertStringContainsString('filename="sample.png"', $options['body']);
+                $this->assertStringContainsString('file-contents', $options['body']);
+
+                return new MockResponseFactory(
+                    (string) file_get_contents('tests/Fixtures/client_file_uploads_send_200.json'),
+                    ['http_code' => 200],
+                );
+            }
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertEquals('single_part', $body['mode']);
+            $this->assertEquals('sample.png', $body['filename']);
+            $this->assertArrayNotHasKey('content_type', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_create_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $fileUpload = $client->fileUploads()->upload('file-contents', 'sample.png');
+
+        $this->assertEquals(FileUpload::STATUS_UPLOADED, $fileUpload->getStatus());
     }
 
     public function testSendFileUpload(): void
@@ -174,12 +223,12 @@ class FileUploadsEndpointTest extends TestCase
 
         $client = new Client((new ClientOptions())->setHttpClient($httpClient));
 
-        $fileUpload = $client->fileUploads()->send(
+        $fileUpload = $client->fileUploads()->sendPart(
             'b52b8ed6-e029-4707-a671-832549c09de3',
             'part-contents',
+            2,
             'sample-large.txt',
             'text/plain',
-            2,
         );
 
         $this->assertEquals(FileUpload::STATUS_UPLOADED, $fileUpload->getStatus());

--- a/tests/Endpoint/FileUploadsEndpointTest.php
+++ b/tests/Endpoint/FileUploadsEndpointTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Client;
+use Brd6\NotionSdkPhp\ClientOptions;
+use Brd6\NotionSdkPhp\Endpoint\FileUploadsEndpoint;
+use Brd6\NotionSdkPhp\Resource\FileUpload;
+use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadListRequest;
+use Brd6\NotionSdkPhp\Resource\FileUpload\FileUploadRequest;
+use Brd6\NotionSdkPhp\Resource\Pagination\FileUploadResults;
+use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
+use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
+use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockResponseFactory;
+use Brd6\Test\NotionSdkPhp\TestCase;
+use DateTimeImmutable;
+
+use function count;
+use function file_get_contents;
+use function json_decode;
+
+class FileUploadsEndpointTest extends TestCase
+{
+    public function testInstance(): void
+    {
+        $client = new Client();
+        $fileUploads = new FileUploadsEndpoint($client);
+
+        $this->assertInstanceOf(FileUploadsEndpoint::class, $client->fileUploads());
+        $this->assertInstanceOf(FileUploadsEndpoint::class, $fileUploads);
+    }
+
+    public function testCreateFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString('file_uploads', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertEquals('single_part', $body['mode']);
+            $this->assertEquals('sample.png', $body['filename']);
+            $this->assertEquals('image/png', $body['content_type']);
+            $this->assertArrayNotHasKey('number_of_parts', $body);
+            $this->assertArrayNotHasKey('external_url', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_create_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $fileUploadRequest = (new FileUploadRequest())
+            ->setMode(FileUploadRequest::MODE_SINGLE_PART)
+            ->setFilename('sample.png')
+            ->setContentType('image/png');
+
+        $fileUpload = $client->fileUploads()->create($fileUploadRequest);
+
+        $this->assertNotEmpty($fileUpload->getId());
+        $this->assertEquals(FileUpload::STATUS_PENDING, $fileUpload->getStatus());
+        $this->assertInstanceOf(DateTimeImmutable::class, $fileUpload->getExpiryTime());
+        $this->assertNotEmpty($fileUpload->getUploadUrl());
+        $this->assertFalse($fileUpload->isInTrash());
+    }
+
+    public function testCreateExternalUrlFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertEquals('external_url', $body['mode']);
+            $this->assertEquals('https://example.com/image.png', $body['external_url']);
+            $this->assertEquals('image.png', $body['filename']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_create_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $fileUploadRequest = (new FileUploadRequest())
+            ->setMode(FileUploadRequest::MODE_EXTERNAL_URL)
+            ->setFilename('image.png')
+            ->setExternalUrl('https://example.com/image.png');
+
+        $fileUpload = $client->fileUploads()->create($fileUploadRequest);
+
+        $this->assertEquals(FileUpload::STATUS_PENDING, $fileUpload->getStatus());
+    }
+
+    public function testCreateMultiPartFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+            $this->assertEquals('multi_part', $body['mode']);
+            $this->assertEquals(2, $body['number_of_parts']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_create_multi_part_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+        $fileUploadRequest = (new FileUploadRequest())
+            ->setMode(FileUploadRequest::MODE_MULTI_PART)
+            ->setFilename('sample-large.txt')
+            ->setContentType('text/plain')
+            ->setNumberOfParts(2);
+
+        $fileUpload = $client->fileUploads()->create($fileUploadRequest);
+
+        $this->assertEquals(['total' => 2, 'sent' => 0], $fileUpload->getNumberOfParts());
+        $this->assertNotEmpty($fileUpload->getCompleteUrl());
+    }
+
+    public function testSendFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString(
+                'file_uploads/b52b8ed6-e029-4707-a671-832549c09de3/send',
+                $url,
+            );
+            $this->assertStringStartsWith(
+                'multipart/form-data; boundary=',
+                $options['headers']['Content-Type'][0],
+            );
+            $this->assertStringContainsString('name="file"', $options['body']);
+            $this->assertStringContainsString('filename="sample.png"', $options['body']);
+            $this->assertStringContainsString('Content-Type: image/png', $options['body']);
+            $this->assertStringContainsString('file-contents', $options['body']);
+            $this->assertStringNotContainsString('part_number', $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_send_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $fileUpload = $client->fileUploads()->send(
+            'b52b8ed6-e029-4707-a671-832549c09de3',
+            'file-contents',
+            'sample.png',
+            'image/png',
+        );
+
+        $this->assertEquals(FileUpload::STATUS_UPLOADED, $fileUpload->getStatus());
+        $this->assertEquals(70, $fileUpload->getContentLength());
+    }
+
+    public function testSendFileUploadPart(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertStringContainsString('name="part_number"', $options['body']);
+            $this->assertStringContainsString('2', $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_send_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $fileUpload = $client->fileUploads()->send(
+            'b52b8ed6-e029-4707-a671-832549c09de3',
+            'part-contents',
+            'sample-large.txt',
+            'text/plain',
+            2,
+        );
+
+        $this->assertEquals(FileUpload::STATUS_UPLOADED, $fileUpload->getStatus());
+    }
+
+    public function testCompleteFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString(
+                'file_uploads/a3f5c1d2-77b4-4e08-9c26-1b52f8d90a14/complete',
+                $url,
+            );
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_complete_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $fileUpload = $client->fileUploads()->complete('a3f5c1d2-77b4-4e08-9c26-1b52f8d90a14');
+
+        $this->assertEquals(FileUpload::STATUS_UPLOADED, $fileUpload->getStatus());
+        $this->assertEquals(['total' => 2, 'sent' => 2], $fileUpload->getNumberOfParts());
+    }
+
+    public function testRetrieveFileUpload(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('GET', $method);
+            $this->assertStringContainsString(
+                'file_uploads/c7e2a9b8-3d61-4f5a-8e07-92c4d1f6b3a5',
+                $url,
+            );
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $fileUpload = $client->fileUploads()->retrieve('c7e2a9b8-3d61-4f5a-8e07-92c4d1f6b3a5');
+
+        $this->assertEquals(FileUpload::STATUS_UPLOADED, $fileUpload->getStatus());
+        $this->assertEquals('success', $fileUpload->getFileImportResult()['type']);
+        $this->assertEquals(['id' => '6794760a-1f15-45cd-9c65-0dfe42f5135a', 'type' => 'bot'], $fileUpload->getCreatedBy());
+    }
+
+    public function testListFileUploads(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('GET', $method);
+            $this->assertStringContainsString('file_uploads', $url);
+            $this->assertEquals('uploaded', $options['query']['status']);
+            $this->assertEquals(2, (int) $options['query']['page_size']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_file_uploads_list_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $listRequest = (new FileUploadListRequest())->setStatus(FileUpload::STATUS_UPLOADED);
+        $paginationRequest = (new PaginationRequest())->setPageSize(2);
+
+        $results = $client->fileUploads()->list($listRequest, $paginationRequest);
+
+        $this->assertInstanceOf(FileUploadResults::class, $results);
+        $this->assertGreaterThan(0, count($results->getResults()));
+        $this->assertInstanceOf(FileUpload::class, $results->getResults()[0]);
+        $this->assertTrue($results->isHasMore());
+        $this->assertNotEmpty($results->getNextCursor());
+    }
+}

--- a/tests/Endpoint/FileUploadsEndpointTest.php
+++ b/tests/Endpoint/FileUploadsEndpointTest.php
@@ -30,6 +30,7 @@ class FileUploadsEndpointTest extends TestCase
 
         $this->assertInstanceOf(FileUploadsEndpoint::class, $client->fileUploads());
         $this->assertInstanceOf(FileUploadsEndpoint::class, $fileUploads);
+        $this->assertEquals('file_upload', (new FileUpload())->getObject());
     }
 
     public function testCreateFileUpload(): void
@@ -160,8 +161,10 @@ class FileUploadsEndpointTest extends TestCase
     public function testSendFileUploadPart(): void
     {
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
-            $this->assertStringContainsString('name="part_number"', $options['body']);
-            $this->assertStringContainsString('2', $options['body']);
+            $this->assertMatchesRegularExpression(
+                '/name="part_number".*?\r\n\r\n2\r\n/s',
+                $options['body'],
+            );
 
             return new MockResponseFactory(
                 (string) file_get_contents('tests/Fixtures/client_file_uploads_send_200.json'),

--- a/tests/Fixtures/client_file_uploads_complete_200.json
+++ b/tests/Fixtures/client_file_uploads_complete_200.json
@@ -1,0 +1,21 @@
+{
+    "object": "file_upload",
+    "id": "a3f5c1d2-77b4-4e08-9c26-1b52f8d90a14",
+    "created_time": "2026-07-13T23:13:00.000Z",
+    "created_by": {
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a",
+        "type": "bot"
+    },
+    "last_edited_time": "2026-07-13T23:14:00.000Z",
+    "expiry_time": "2026-07-14T00:13:00.000Z",
+    "in_trash": false,
+    "status": "uploaded",
+    "filename": "sample-large.txt",
+    "content_type": "text/plain",
+    "content_length": 5242884,
+    "number_of_parts": {
+        "total": 2,
+        "sent": 2
+    },
+    "archived": false
+}

--- a/tests/Fixtures/client_file_uploads_create_200.json
+++ b/tests/Fixtures/client_file_uploads_create_200.json
@@ -1,0 +1,18 @@
+{
+    "object": "file_upload",
+    "id": "b52b8ed6-e029-4707-a671-832549c09de3",
+    "created_time": "2026-07-13T23:13:00.000Z",
+    "created_by": {
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a",
+        "type": "bot"
+    },
+    "last_edited_time": "2026-07-13T23:13:00.000Z",
+    "expiry_time": "2026-07-14T00:13:00.000Z",
+    "upload_url": "https://api.notion.com/v1/file_uploads/b52b8ed6-e029-4707-a671-832549c09de3/send",
+    "in_trash": false,
+    "status": "pending",
+    "filename": "sample.png",
+    "content_type": "image/png",
+    "content_length": null,
+    "archived": false
+}

--- a/tests/Fixtures/client_file_uploads_create_multi_part_200.json
+++ b/tests/Fixtures/client_file_uploads_create_multi_part_200.json
@@ -1,0 +1,23 @@
+{
+    "object": "file_upload",
+    "id": "a3f5c1d2-77b4-4e08-9c26-1b52f8d90a14",
+    "created_time": "2026-07-13T23:13:00.000Z",
+    "created_by": {
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a",
+        "type": "bot"
+    },
+    "last_edited_time": "2026-07-13T23:13:00.000Z",
+    "expiry_time": "2026-07-14T00:13:00.000Z",
+    "upload_url": "https://api.notion.com/v1/file_uploads/a3f5c1d2-77b4-4e08-9c26-1b52f8d90a14/send",
+    "complete_url": "https://api.notion.com/v1/file_uploads/a3f5c1d2-77b4-4e08-9c26-1b52f8d90a14/complete",
+    "in_trash": false,
+    "status": "pending",
+    "filename": "sample-large.txt",
+    "content_type": "text/plain",
+    "content_length": null,
+    "number_of_parts": {
+        "total": 2,
+        "sent": 0
+    },
+    "archived": false
+}

--- a/tests/Fixtures/client_file_uploads_list_200.json
+++ b/tests/Fixtures/client_file_uploads_list_200.json
@@ -1,0 +1,26 @@
+{
+    "object": "list",
+    "results": [
+        {
+            "object": "file_upload",
+            "id": "b52b8ed6-e029-4707-a671-832549c09de3",
+            "created_time": "2026-07-13T23:13:00.000Z",
+            "created_by": {
+                "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a",
+                "type": "bot"
+            },
+            "last_edited_time": "2026-07-13T23:13:00.000Z",
+            "expiry_time": "2026-07-14T00:13:00.000Z",
+            "in_trash": false,
+            "status": "uploaded",
+            "filename": "sample.png",
+            "content_type": "image/png",
+            "content_length": 70,
+            "archived": false
+        }
+    ],
+    "next_cursor": "c7e2a9b8-3d61-4f5a-8e07-92c4d1f6b3a5",
+    "has_more": true,
+    "type": "file_upload",
+    "file_upload": {}
+}

--- a/tests/Fixtures/client_file_uploads_retrieve_200.json
+++ b/tests/Fixtures/client_file_uploads_retrieve_200.json
@@ -1,0 +1,22 @@
+{
+    "object": "file_upload",
+    "id": "c7e2a9b8-3d61-4f5a-8e07-92c4d1f6b3a5",
+    "created_time": "2026-07-13T23:13:00.000Z",
+    "created_by": {
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a",
+        "type": "bot"
+    },
+    "last_edited_time": "2026-07-13T23:13:00.000Z",
+    "expiry_time": "2026-07-14T00:13:00.000Z",
+    "in_trash": false,
+    "status": "uploaded",
+    "filename": "favicon.ico",
+    "content_type": "image/vnd.microsoft.icon",
+    "content_length": 32038,
+    "file_import_result": {
+        "type": "success",
+        "success": [],
+        "imported_time": "2026-07-13T23:13:09.000+00:00"
+    },
+    "archived": false
+}

--- a/tests/Fixtures/client_file_uploads_send_200.json
+++ b/tests/Fixtures/client_file_uploads_send_200.json
@@ -1,0 +1,17 @@
+{
+    "object": "file_upload",
+    "id": "b52b8ed6-e029-4707-a671-832549c09de3",
+    "created_time": "2026-07-13T23:13:00.000Z",
+    "created_by": {
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a",
+        "type": "bot"
+    },
+    "last_edited_time": "2026-07-13T23:13:00.000Z",
+    "expiry_time": "2026-07-14T00:13:00.000Z",
+    "in_trash": false,
+    "status": "uploaded",
+    "filename": "sample.png",
+    "content_type": "image/png",
+    "content_length": 70,
+    "archived": false
+}

--- a/tests/Resource/File/FileUploadTest.php
+++ b/tests/Resource/File/FileUploadTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource\File;
+
+use Brd6\NotionSdkPhp\Exception\UnsupportedFileTypeException;
+use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
+use Brd6\NotionSdkPhp\Resource\Block\ImageBlock;
+use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
+use Brd6\NotionSdkPhp\Resource\File\FileUpload;
+use Brd6\NotionSdkPhp\Resource\Property\FileUploadProperty;
+use Brd6\Test\NotionSdkPhp\TestCase;
+
+class FileUploadTest extends TestCase
+{
+    public function testUnsupportedFileTypeStillThrows(): void
+    {
+        $this->expectException(UnsupportedFileTypeException::class);
+
+        AbstractFile::fromRawData([
+            'type' => 'unknown_file_type',
+            'unknown_file_type' => [],
+        ]);
+    }
+
+    public function testFromRawData(): void
+    {
+        $file = AbstractFile::fromRawData([
+            'type' => 'file_upload',
+            'file_upload' => [
+                'id' => 'b52b8ed6-e029-4707-a671-832549c09de3',
+            ],
+        ]);
+
+        $this->assertInstanceOf(FileUpload::class, $file);
+        $this->assertEquals('file_upload', $file->getType());
+        $this->assertNotNull($file->getFileUpload());
+        $this->assertEquals('b52b8ed6-e029-4707-a671-832549c09de3', $file->getFileUpload()->getId());
+    }
+
+    public function testSerialize(): void
+    {
+        $file = new FileUpload();
+        $file->setFileUpload((new FileUploadProperty())->setId('b52b8ed6-e029-4707-a671-832549c09de3'));
+
+        $this->assertEquals([
+            'type' => 'file_upload',
+            'file_upload' => [
+                'id' => 'b52b8ed6-e029-4707-a671-832549c09de3',
+            ],
+        ], $file->toArray());
+    }
+
+    public function testImageBlockWithFileUploadHydrates(): void
+    {
+        $block = AbstractBlock::fromRawData([
+            'object' => 'block',
+            'id' => '0c940186-ab70-4351-bb34-2d16f0635d49',
+            'created_time' => '2026-07-13T23:13:00.000Z',
+            'last_edited_time' => '2026-07-13T23:13:00.000Z',
+            'created_by' => [
+                'object' => 'user',
+                'id' => 'd0063369-46a4-4756-8798-0d36d53c9b20',
+            ],
+            'last_edited_by' => [
+                'object' => 'user',
+                'id' => 'd0063369-46a4-4756-8798-0d36d53c9b20',
+            ],
+            'has_children' => false,
+            'archived' => false,
+            'type' => 'image',
+            'image' => [
+                'type' => 'file_upload',
+                'file_upload' => [
+                    'id' => 'b52b8ed6-e029-4707-a671-832549c09de3',
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ImageBlock::class, $block);
+
+        $image = $block->getImage();
+        $this->assertInstanceOf(FileUpload::class, $image);
+        $this->assertEquals('b52b8ed6-e029-4707-a671-832549c09de3', $image->getFileUpload()->getId());
+    }
+}


### PR DESCRIPTION
## Description

Adds support for the [Notion File Upload API](https://developers.notion.com/reference/create-a-file-upload) via a new `FileUploadsEndpoint` exposed as `$notion->fileUploads()`:

- `create(?FileUploadRequest $request = null): FileUpload` — `POST /v1/file_uploads`; per-mode static constructors (`FileUploadRequest::singlePart()`, `::multiPart()`, `::externalUrl()`) make each mode's required fields explicit, and a bare `create()` uses the API's `single_part` default.
- `upload($contents, $filename, ?$contentType = null): FileUpload` — one-call convenience for the common case: creates a single-part upload and sends the bytes; Notion derives the content type from the filename.
- `send($id, $contents, $filename, ?$contentType = null): FileUpload` and `sendPart($id, $contents, $partNumber, $filename, ?$contentType = null): FileUpload` — `POST /v1/file_uploads/{id}/send`, building the `multipart/form-data` body with `php-http/multipart-stream-builder`; `sendPart()` carries the `part_number` field for multi-part uploads.
- `complete($id): FileUpload` — `POST /v1/file_uploads/{id}/complete`.
- `retrieve($id): FileUpload` — `GET /v1/file_uploads/{id}`, exposing status, expiry, and the `file_import_result` for `external_url` imports.
- `list(?FileUploadListRequest, ?PaginationRequest)` — `GET /v1/file_uploads` with status filtering and pagination via a new `FileUploadResults`.

It also adds the `file_upload` **file-object type** (`Resource\File\FileUpload` + `FileUploadProperty`). Previously, hydrating any block that references an uploaded file threw `UnsupportedFileTypeException`, so a page holding an uploaded image could not be read back; it now hydrates and round-trips.

The `examples/09-file-uploads-api-smoke` example now drives the whole flow through the endpoint instead of raw requests, and the README gains a "File uploads" section.

## Motivation and context

The request model gained multipart support in #77; this PR ships the endpoint that needs it. The File Upload API is otherwise unreachable through the SDK, and files uploaded through it are unreadable on hydration.

Note: attaching an uploaded file to a page via `blocks()->children()->append()` requires #78, which fixes child-block serialization independently of this PR.

## How has this been tested?

- 13 new PHPUnit cases: create bodies for all three modes, multipart send assertions (boundary `Content-Type` header, `file` part with filename and content type, `part_number` part), complete, retrieve (including `file_import_result`), list (status + pagination query, `FileUploadResults` hydration), the `UnsupportedFileTypeException` regression, `file_upload` file-object hydration and serialization round-trip, and an image block carrying a `file_upload` reference.
- Fixtures are shaped from real API responses captured against a live workspace (ids anonymized).
- Verified live against the Notion API: created a file upload, sent the bytes as multipart through `fileUploads()->send()`, confirmed `status: uploaded` via `retrieve()`, attached the upload to a page as an image block, and listed recent uploads. The `multi_part` mode is validated by unit tests only — it requires a paid workspace, and the mocked shapes for it follow the API reference.
- Full suite green (148 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
