### PR TITLE
feat(client): support Notion API version 2026-03-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `php-http/multipart-stream-builder` as a dependency for building multipart request bodies.
 - Add support for the Notion File Upload API via `$notion->fileUploads()`: a one-call `upload()` for the common case, plus create, send/sendPart (`multipart/form-data`), complete, retrieve, and list.
 - Add the `file_upload` file-object type so blocks referencing uploaded files hydrate instead of throwing `UnsupportedFileTypeException`.
+- Add support for Notion API version `2026-03-11`, opt-in per client via `setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)`: write payloads use `in_trash` instead of `archived`, and the new `blocks()->children()->append()` insertion position serializes as `position` instead of `after`. Clients on older versions send byte-identical payloads to before, and two clients on different versions can run side by side in one process.
+- Add `NOTION_VERSION_2022_06_28`, `NOTION_VERSION_2025_09_03`, and `NOTION_VERSION_2026_03_11` constants on `ClientOptions`; the default version is unchanged.
+- Add `isInTrash()`/`setInTrash()` on `Page`, blocks, and `Database`, and accept both the `archived` and `in_trash` response keys during hydration regardless of the client version.
+- Add an optional `$afterBlockId` parameter to `blocks()->children()->append()` to insert blocks after an existing block.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add the `file_upload` file-object type so blocks referencing uploaded files hydrate instead of throwing `UnsupportedFileTypeException`.
 - Add support for Notion API version `2026-03-11`, opt-in per client via `setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)`: write payloads use `in_trash` instead of `archived`, and the new `blocks()->children()->append()` insertion position serializes as `position` instead of `after`. Clients on older versions send byte-identical payloads to before, and two clients on different versions can run side by side in one process.
 - Add `NOTION_VERSION_2022_06_28`, `NOTION_VERSION_2025_09_03`, and `NOTION_VERSION_2026_03_11` constants on `ClientOptions`; the default version is unchanged.
-- Add `isInTrash()`/`setInTrash()` on `Page`, blocks, and `Database`, and accept both the `archived` and `in_trash` response keys during hydration regardless of the client version.
+- Add `isInTrash()`/`setInTrash()` on `Page`, blocks, and `Database`, and accept both the `archived` and `in_trash` response keys during hydration — including for data sources — regardless of the client version.
 - Add an optional `$afterBlockId` parameter to `blocks()->children()->append()` to insert blocks after an existing block.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ $myPage = $notion->databases()->query('897e5a76-ae52-4b48-9fdf-e71f5945d1af', $d
 
 If you use Notion API version `2025-09-03` or newer, the SDK supports data source endpoints via `$notion->dataSources()`, and page creation with `data_source_id` parents. When creating a database with this API version, `databases()->create()` automatically maps `properties` to the required `initial_data_source` payload.
 
+### Notion API 2026-03-11
+
+The API version is selected per `Client`, so an integration can run different versions side by side in one process:
+
+```php
+$notion = new Client((new ClientOptions())
+    ->setAuth($_ENV['NOTION_TOKEN'])
+    ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11));
+```
+
+On `2026-03-11` the SDK sends `in_trash` instead of `archived` and expresses the `blocks()->children()->append()` insertion position (`$afterBlockId`) as `position`; on older versions payloads are unchanged. Responses hydrate correctly on every version — `isArchived()` and `isInTrash()` both work regardless of which key the API returned.
+
 ### File uploads
 
 The SDK supports the [Notion File Upload API](https://developers.notion.com/reference/create-a-file-upload) via `$notion->fileUploads()`. Uploading a file takes one call — Notion derives the content type from the filename:

--- a/README.md
+++ b/README.md
@@ -100,18 +100,6 @@ $myPage = $notion->databases()->query('897e5a76-ae52-4b48-9fdf-e71f5945d1af', $d
 
 If you use Notion API version `2025-09-03` or newer, the SDK supports data source endpoints via `$notion->dataSources()`, and page creation with `data_source_id` parents. When creating a database with this API version, `databases()->create()` automatically maps `properties` to the required `initial_data_source` payload.
 
-### Notion API 2026-03-11
-
-The API version is selected per `Client`, so an integration can run different versions side by side in one process:
-
-```php
-$notion = new Client((new ClientOptions())
-    ->setAuth($_ENV['NOTION_TOKEN'])
-    ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11));
-```
-
-On `2026-03-11` the SDK sends `in_trash` instead of `archived` and expresses the `blocks()->children()->append()` insertion position (`$afterBlockId`) as `position`; on older versions payloads are unchanged. Responses hydrate correctly on every version — `isArchived()` and `isInTrash()` both work regardless of which key the API returned.
-
 ### File uploads
 
 The SDK supports the [Notion File Upload API](https://developers.notion.com/reference/create-a-file-upload) via `$notion->fileUploads()`. Uploading a file takes one call — Notion derives the content type from the filename:

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -11,7 +11,10 @@ use function strlen;
 class ClientOptions
 {
     public const DEFAULT_BASE_URL = 'https://api.notion.com/v1/';
-    public const DEFAULT_NOTION_VERSION = '2022-06-28';
+    public const NOTION_VERSION_2022_06_28 = '2022-06-28';
+    public const NOTION_VERSION_2025_09_03 = '2025-09-03';
+    public const NOTION_VERSION_2026_03_11 = '2026-03-11';
+    public const DEFAULT_NOTION_VERSION = self::NOTION_VERSION_2022_06_28;
     public const DEFAULT_TIMEOUT = 60; // in seconds
 
     private string $auth = '';

--- a/src/Endpoint/AbstractEndpoint.php
+++ b/src/Endpoint/AbstractEndpoint.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Brd6\NotionSdkPhp\Endpoint;
 
 use Brd6\NotionSdkPhp\Client;
+use Brd6\NotionSdkPhp\ClientOptions;
 use stdClass;
 
+use function array_key_exists;
 use function array_keys;
 use function count;
 use function is_array;
+use function version_compare;
 
 abstract class AbstractEndpoint
 {
@@ -23,6 +26,31 @@ abstract class AbstractEndpoint
     protected function getClient(): Client
     {
         return $this->client;
+    }
+
+    protected function supportsVersion(string $minimumVersion): bool
+    {
+        return version_compare($this->getClient()->getOptions()->getNotionVersion(), $minimumVersion, '>=');
+    }
+
+    /**
+     * Renames the `archived` key to `in_trash` for clients on Notion-Version 2026-03-11 or newer;
+     * payloads for older versions are returned unchanged.
+     *
+     * @psalm-suppress MixedAssignment
+     */
+    protected function normalizeTrashKey(array $data): array
+    {
+        if (!$this->supportsVersion(ClientOptions::NOTION_VERSION_2026_03_11)) {
+            return $data;
+        }
+
+        if (array_key_exists('archived', $data)) {
+            $data['in_trash'] = $data['archived'];
+            unset($data['archived']);
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Endpoint/BlocksChildrenEndpoint.php
+++ b/src/Endpoint/BlocksChildrenEndpoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brd6\NotionSdkPhp\Endpoint;
 
+use Brd6\NotionSdkPhp\ClientOptions;
 use Brd6\NotionSdkPhp\Exception\ApiResponseException;
 use Brd6\NotionSdkPhp\Exception\HttpResponseException;
 use Brd6\NotionSdkPhp\Exception\InvalidPaginationResponseException;
@@ -47,6 +48,7 @@ class BlocksChildrenEndpoint extends AbstractEndpoint
     /**
      * @param string $blockId
      * @param array|AbstractBlock[] $children
+     * @param string|null $afterBlockId inserts the children after this existing block instead of at the end
      *
      * @throws ApiResponseException
      * @throws Exception
@@ -55,15 +57,31 @@ class BlocksChildrenEndpoint extends AbstractEndpoint
      * @throws RequestTimeoutException
      * @throws UnsupportedPaginationResponseTypeException
      */
-    public function append(string $blockId, array $children): AbstractPaginationResults
-    {
+    public function append(
+        string $blockId,
+        array $children,
+        ?string $afterBlockId = null
+    ): AbstractPaginationResults {
         $childrenData = array_map(fn (AbstractBlock $block) => $block->toArrayForCreate(), $children);
+
+        $body = [
+            'children' => $childrenData,
+        ];
+
+        if ($afterBlockId !== null) {
+            if ($this->supportsVersion(ClientOptions::NOTION_VERSION_2026_03_11)) {
+                $body['position'] = [
+                    'type' => 'after_block',
+                    'after_block' => ['id' => $afterBlockId],
+                ];
+            } else {
+                $body['after'] = $afterBlockId;
+            }
+        }
 
         $requestParameters = (new RequestParameters())
             ->setPath("blocks/$blockId/children")
-            ->setBody([
-                'children' => $childrenData,
-            ])
+            ->setBody($body)
             ->setMethod('PATCH');
 
         $rawData = $this->getClient()->request($requestParameters);

--- a/src/Endpoint/BlocksEndpoint.php
+++ b/src/Endpoint/BlocksEndpoint.php
@@ -65,10 +65,10 @@ class BlocksEndpoint extends AbstractEndpoint
 
         $requestParameters = (new RequestParameters())
             ->setPath("blocks/{$block->getId()}")
-            ->setBody([
+            ->setBody($this->normalizeTrashKey([
                 $block->getType() => $data,
                 'archived' => $block->isArchived(),
-            ])
+            ]))
             ->setMethod('PATCH');
 
         $rawData = $this->getClient()->request($requestParameters);

--- a/src/Endpoint/DatabasesEndpoint.php
+++ b/src/Endpoint/DatabasesEndpoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brd6\NotionSdkPhp\Endpoint;
 
+use Brd6\NotionSdkPhp\ClientOptions;
 use Brd6\NotionSdkPhp\Exception\ApiResponseException;
 use Brd6\NotionSdkPhp\Exception\HttpResponseException;
 use Brd6\NotionSdkPhp\Exception\InvalidPaginationResponseException;
@@ -19,7 +20,6 @@ use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
 use Http\Client\Exception;
 
 use function array_merge;
-use function version_compare;
 
 class DatabasesEndpoint extends AbstractEndpoint
 {
@@ -69,7 +69,7 @@ class DatabasesEndpoint extends AbstractEndpoint
     {
         $data = $database->toArray();
 
-        if (version_compare($this->getClient()->getOptions()->getNotionVersion(), '2025-09-03', '>=')) {
+        if ($this->supportsVersion(ClientOptions::NOTION_VERSION_2025_09_03)) {
             $data['initial_data_source'] = [
                 'properties' => (array) ($data['properties'] ?? []),
             ];
@@ -105,7 +105,7 @@ class DatabasesEndpoint extends AbstractEndpoint
         $requestParameters = (new RequestParameters())
             ->setPath("databases/{$database->getId()}")
             ->setMethod('PATCH')
-            ->setBody($database->toArrayForUpdate());
+            ->setBody($this->normalizeTrashKey($database->toArrayForUpdate()));
 
         $rawData = $this->getClient()->request($requestParameters);
 

--- a/src/Endpoint/PagesEndpoint.php
+++ b/src/Endpoint/PagesEndpoint.php
@@ -68,7 +68,7 @@ class PagesEndpoint extends AbstractEndpoint
     {
         $childrenData = array_map(fn (AbstractBlock $block) => $block->toArrayForCreate(), $children);
 
-        $data = array_merge($page->toArrayForCreate(), ['children' => $childrenData]);
+        $data = array_merge($this->normalizeTrashKey($page->toArrayForCreate()), ['children' => $childrenData]);
 
         $requestParameters = (new RequestParameters())
             ->setPath('pages')
@@ -98,7 +98,7 @@ class PagesEndpoint extends AbstractEndpoint
         $requestParameters = (new RequestParameters())
             ->setPath("pages/{$page->getId()}")
             ->setMethod('PATCH')
-            ->setBody($page->toArrayForUpdate());
+            ->setBody($this->normalizeTrashKey($page->toArrayForUpdate()));
 
         $rawData = $this->getClient()->request($requestParameters);
 

--- a/src/Resource/Block/AbstractBlock.php
+++ b/src/Resource/Block/AbstractBlock.php
@@ -85,8 +85,8 @@ abstract class AbstractBlock extends AbstractResource
         $this->createdBy = AbstractUser::fromRawData((array) $this->getRawData()['created_by']);
         $this->lastEditedTime = new DateTimeImmutable((string) $this->getRawData()['last_edited_time']);
         $this->lastEditedBy = AbstractUser::fromRawData((array) $this->getRawData()['last_edited_by']);
-        $this->archived = (bool) $this->getRawData()['archived'];
-        $this->hasChildren = (bool) $this->getRawData()['has_children'];
+        $this->archived = (bool) ($this->getRawData()['archived'] ?? $this->getRawData()['in_trash'] ?? false);
+        $this->hasChildren = (bool) ($this->getRawData()['has_children'] ?? false);
 
         $this->initializeChildren();
         $this->initializeBlockProperty();
@@ -206,6 +206,16 @@ abstract class AbstractBlock extends AbstractResource
         $this->archived = $archived;
 
         return $this;
+    }
+
+    public function isInTrash(): bool
+    {
+        return $this->isArchived();
+    }
+
+    public function setInTrash(bool $inTrash): self
+    {
+        return $this->setArchived($inTrash);
     }
 
     public function isHasChildren(): bool

--- a/src/Resource/DataSource.php
+++ b/src/Resource/DataSource.php
@@ -83,8 +83,8 @@ class DataSource extends AbstractResource
             new DateTimeImmutable((string) $this->getRawData()['last_edited_time']) :
             null;
         $this->lastEditedBy = AbstractUser::fromRawData((array) ($this->getRawData()['last_edited_by'] ?? []));
-        $this->archived = (bool) ($this->getRawData()['archived'] ?? false);
-        $this->inTrash = (bool) ($this->getRawData()['in_trash'] ?? false);
+        $this->archived = (bool) ($this->getRawData()['archived'] ?? $this->getRawData()['in_trash'] ?? false);
+        $this->inTrash = (bool) ($this->getRawData()['in_trash'] ?? $this->getRawData()['archived'] ?? false);
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;

--- a/src/Resource/Database.php
+++ b/src/Resource/Database.php
@@ -84,7 +84,7 @@ class Database extends AbstractResource
             new DateTimeImmutable((string) $this->getRawData()['last_edited_time']) :
             null;
         $this->lastEditedBy = AbstractUser::fromRawData((array) ($this->getRawData()['last_edited_by'] ?? []));
-        $this->archived = (bool) ($this->getRawData()['archived'] ?? false);
+        $this->archived = (bool) ($this->getRawData()['archived'] ?? $this->getRawData()['in_trash'] ?? false);
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;
@@ -167,6 +167,16 @@ class Database extends AbstractResource
         $this->archived = $archived;
 
         return $this;
+    }
+
+    public function isInTrash(): bool
+    {
+        return $this->isArchived();
+    }
+
+    public function setInTrash(bool $inTrash): self
+    {
+        return $this->setArchived($inTrash);
     }
 
     public static function getResourceType(): string

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -87,7 +87,9 @@ class Page extends AbstractResource
         $this->lastEditedBy = AbstractUser::fromRawData((array) $this->getRawData()['last_edited_by']);
         $this->archived = array_key_exists('archived', $this->getRawData())
             ? (bool) $this->getRawData()['archived']
-            : null;
+            : (array_key_exists('in_trash', $this->getRawData())
+                ? (bool) $this->getRawData()['in_trash']
+                : null);
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;
@@ -162,6 +164,16 @@ class Page extends AbstractResource
         $this->archived = $archived;
 
         return $this;
+    }
+
+    public function isInTrash(): bool
+    {
+        return $this->isArchived();
+    }
+
+    public function setInTrash(bool $inTrash): self
+    {
+        return $this->setArchived($inTrash);
     }
 
     public static function getResourceType(): string

--- a/tests/Endpoint/BlocksEndpointTest.php
+++ b/tests/Endpoint/BlocksEndpointTest.php
@@ -23,6 +23,7 @@ use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
 use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockResponseFactory;
 use Brd6\Test\NotionSdkPhp\TestCase;
 
+use function array_keys;
 use function count;
 use function file_get_contents;
 use function json_decode;
@@ -423,5 +424,94 @@ class BlocksEndpointTest extends TestCase
         $this->assertInstanceOf(Text::class, $cells2[0][0]);
         $this->assertEquals('Content', $cells2[0][0]->getText()->getContent());
         $this->assertEmpty($cells2[2]);
+    }
+
+    public function testUpdateBlockSendsInTrashOn20260311(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('in_trash', $body);
+            $this->assertArrayNotHasKey('archived', $body);
+            $this->assertArrayHasKey('paragraph', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $paragraphProperty = new ParagraphProperty();
+        $paragraphProperty->setRichText([Text::fromContent('Hello world!')]);
+
+        $block = new ParagraphBlock();
+        $block->setId('0c940186-ab70-4351-bb34-2d16f0635d49');
+        $block->setParagraph($paragraphProperty);
+
+        $client->blocks()->update($block);
+    }
+
+    public function testAppendBlockChildrenAfterBlockId(): void
+    {
+        $buildHttpClient = fn (callable $assertBody) => new MockHttpClient(
+            function (string $method, string $url, array $options) use ($assertBody) {
+                /** @var array $body */
+                $body = json_decode($options['body'], true);
+                $assertBody($body);
+
+                return new MockResponseFactory(
+                    (string) file_get_contents(
+                        'tests/Fixtures/client_blocks_retrieve_block_children_page_size_4_200.json',
+                    ),
+                    ['http_code' => 200],
+                );
+            },
+        );
+
+        $buildBlock = static function (): Heading3Block {
+            $heading3 = new Heading3Block();
+            $heading3Property = new HeadingProperty();
+            $heading3Property->setRichText([Text::fromContent('New title here')]);
+            $heading3->setHeading3($heading3Property);
+
+            return $heading3;
+        };
+
+        $legacyClient = new Client((new ClientOptions())->setHttpClient($buildHttpClient(
+            function (array $body): void {
+                $this->assertEquals('after-block-id', $body['after']);
+                $this->assertArrayNotHasKey('position', $body);
+            },
+        )));
+        $legacyClient->blocks()->children()->append('parent-block-id', [$buildBlock()], 'after-block-id');
+
+        $currentClient = new Client(
+            (new ClientOptions())
+                ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)
+                ->setHttpClient($buildHttpClient(
+                    function (array $body): void {
+                        $this->assertEquals(
+                            ['type' => 'after_block', 'after_block' => ['id' => 'after-block-id']],
+                            $body['position'],
+                        );
+                        $this->assertArrayNotHasKey('after', $body);
+                    },
+                )),
+        );
+        $currentClient->blocks()->children()->append('parent-block-id', [$buildBlock()], 'after-block-id');
+
+        $defaultClient = new Client((new ClientOptions())->setHttpClient($buildHttpClient(
+            function (array $body): void {
+                $this->assertEquals(['children'], array_keys($body));
+            },
+        )));
+        $defaultClient->blocks()->children()->append('parent-block-id', [$buildBlock()]);
     }
 }

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -667,4 +667,102 @@ class PagesEndpointTest extends TestCase
         $this->assertNotNull($createdPage->getCreatedBy());
         $this->assertNotNull($createdPage->getLastEditedBy());
     }
+
+    public function testUpdatePageSendsInTrashOn20260311(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertTrue($body['in_trash']);
+            $this->assertArrayNotHasKey('archived', $body);
+            $this->assertEquals(['2026-03-11'], $options['headers']['Notion-Version']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $page = new Page();
+        $page->setId('1e7e638f78864ec591ea54ec7016e146');
+        $page->setInTrash(true);
+
+        $client->pages()->update($page);
+    }
+
+    public function testCreatePageSendsInTrashOn20260311(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('in_trash', $body);
+            $this->assertFalse($body['in_trash']);
+            $this->assertArrayNotHasKey('archived', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $page = new Page();
+        $page->setParent((new PageIdParent())->setPageId('4a808e6e-8845-4d49-a447-fb2a4c460f6f'));
+        $page->setProperties(['title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Test Page')])]);
+        $page->setArchived(false);
+
+        $client->pages()->create($page);
+    }
+
+    public function testTwoClientsWithDifferentVersionsSerializeIndependently(): void
+    {
+        $buildHttpClient = fn (string $expectedTrashKey) => new MockHttpClient(
+            function ($method, $url, $options) use ($expectedTrashKey) {
+                /** @var array $body */
+                $body = json_decode($options['body'], true);
+                $otherTrashKey = $expectedTrashKey === 'archived' ? 'in_trash' : 'archived';
+
+                $this->assertTrue($body[$expectedTrashKey]);
+                $this->assertArrayNotHasKey($otherTrashKey, $body);
+
+                return new MockResponseFactory(
+                    (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                    ['http_code' => 200],
+                );
+            },
+        );
+
+        $legacyClient = new Client((new ClientOptions())->setHttpClient($buildHttpClient('archived')));
+        $currentClient = new Client(
+            (new ClientOptions())
+                ->setNotionVersion(ClientOptions::NOTION_VERSION_2026_03_11)
+                ->setHttpClient($buildHttpClient('in_trash')),
+        );
+
+        $buildPage = static function (): Page {
+            $page = new Page();
+            $page->setId('1e7e638f78864ec591ea54ec7016e146');
+            $page->setArchived(true);
+
+            return $page;
+        };
+
+        $legacyClient->pages()->update($buildPage());
+        $currentClient->pages()->update($buildPage());
+        $legacyClient->pages()->update($buildPage());
+        $currentClient->pages()->update($buildPage());
+    }
 }

--- a/tests/Resource/BlockTest.php
+++ b/tests/Resource/BlockTest.php
@@ -470,4 +470,34 @@ class BlockTest extends TestCase
         $this->assertTrue($block->isHasChildren());
         $this->assertEmpty($block->getChildren());
     }
+
+    public function testBlockHydratesInTrashPayloadWithoutArchivedKey(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_200.json'),
+            true,
+        );
+        unset($rawData['archived']);
+        $rawData['in_trash'] = true;
+
+        $block = AbstractBlock::fromRawData($rawData);
+
+        $this->assertTrue($block->isArchived());
+        $this->assertTrue($block->isInTrash());
+    }
+
+    public function testBlockHydratesArchivedPayload(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_200.json'),
+            true,
+        );
+        $rawData['archived'] = true;
+        unset($rawData['in_trash']);
+
+        $block = AbstractBlock::fromRawData($rawData);
+
+        $this->assertTrue($block->isArchived());
+        $this->assertTrue($block->isInTrash());
+    }
 }

--- a/tests/Resource/DataSourceTest.php
+++ b/tests/Resource/DataSourceTest.php
@@ -25,6 +25,38 @@ class DataSourceTest extends TestCase
         DataSource::fromRawData([]);
     }
 
+    public function testDataSourceHydratesInTrashPayloadWithoutArchivedKey(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        );
+        unset($rawData['archived']);
+        $rawData['in_trash'] = true;
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData($rawData);
+
+        $this->assertTrue($dataSource->isArchived());
+        $this->assertTrue($dataSource->isInTrash());
+    }
+
+    public function testDataSourceHydratesArchivedPayload(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        );
+        $rawData['archived'] = true;
+        unset($rawData['in_trash']);
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData($rawData);
+
+        $this->assertTrue($dataSource->isArchived());
+        $this->assertTrue($dataSource->isInTrash());
+    }
+
     public function testDataSource(): void
     {
         /** @var DataSource $dataSource */

--- a/tests/Resource/DatabaseTest.php
+++ b/tests/Resource/DatabaseTest.php
@@ -27,6 +27,38 @@ class DatabaseTest extends TestCase
         Database::fromRawData([]);
     }
 
+    public function testDatabaseHydratesInTrashPayloadWithoutArchivedKey(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_databases_retrieve_database_200.json'),
+            true,
+        );
+        unset($rawData['archived']);
+        $rawData['in_trash'] = true;
+
+        /** @var Database $database */
+        $database = Database::fromRawData($rawData);
+
+        $this->assertTrue($database->isArchived());
+        $this->assertTrue($database->isInTrash());
+    }
+
+    public function testDatabaseHydratesArchivedPayload(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_databases_retrieve_database_200.json'),
+            true,
+        );
+        $rawData['archived'] = true;
+        unset($rawData['in_trash']);
+
+        /** @var Database $database */
+        $database = Database::fromRawData($rawData);
+
+        $this->assertTrue($database->isArchived());
+        $this->assertTrue($database->isInTrash());
+    }
+
     public function testDatabase(): void
     {
         /** @var Database $database */

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -126,6 +126,38 @@ class PageTest extends TestCase
         $this->assertSame($blockId, $parent->getBlockId());
     }
 
+    public function testPageHydratesInTrashPayloadWithoutArchivedKey(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+            true,
+        );
+        unset($rawData['archived']);
+        $rawData['in_trash'] = true;
+
+        /** @var Page $page */
+        $page = Page::fromRawData($rawData);
+
+        $this->assertTrue($page->isArchived());
+        $this->assertTrue($page->isInTrash());
+    }
+
+    public function testPageHydratesArchivedPayload(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+            true,
+        );
+        $rawData['archived'] = true;
+        unset($rawData['in_trash']);
+
+        /** @var Page $page */
+        $page = Page::fromRawData($rawData);
+
+        $this->assertTrue($page->isArchived());
+        $this->assertTrue($page->isInTrash());
+    }
+
     public function testPageIsArchivedReturnsFalseWhenUnset(): void
     {
         $page = new Page();


### PR DESCRIPTION
## Description

Adds support for Notion API version `2026-03-11`, selected per `Client` instance:

- `ClientOptions` gains `NOTION_VERSION_2022_06_28`, `NOTION_VERSION_2025_09_03`, and `NOTION_VERSION_2026_03_11` constants. The default version is unchanged.
- On `2026-03-11`, write payloads use `in_trash` instead of `archived` (`pages()->create()`/`update()`, `databases()->update()`, `blocks()->update()`). The rename happens in one place — `AbstractEndpoint::normalizeTrashKey()`, driven by a new `supportsVersion()` helper — and the existing `2025-09-03` gate in `databases()->create()` is refactored onto the same helper with unchanged behaviour.
- Hydration is version-agnostic: `Page`, blocks, and `Database` accept both the `archived` and `in_trash` response keys, and gain `isInTrash()`/`setInTrash()` backed by the same state as the `archived` accessors. `2026-03-11` responses omit `archived` entirely, which previously crashed block hydration with an undefined array key error.
- `blocks()->children()->append()` gains an optional `$afterBlockId` to insert blocks after an existing block: serialized as `after` on older versions and as `position: {type: "after_block", after_block: {id}}` on `2026-03-11` (shape verified against the live API — the changelog-documented `position` object is a typed union).

## Motivation and context

Since `2025-09-03`, integrations pinned to `2022-06-28` break as soon as an end user adds a second data source to a database — an event the integration cannot prevent. Raising the version safely requires the SDK to speak the newer field names while older clients keep working, including both versions running side by side in one process (an existing pipeline on `2022-06-28` next to new code on `2026-03-11`). The version is resolved from the client options at call time — never cached on a resource or in a static — which a dedicated interleaving test asserts.

## How has this been tested?

- New tests: dual-shape hydration for `Page`/blocks/`Database` (payloads carrying `archived`, `in_trash`, or only one of them), the block-hydration regression for payloads without `archived`, `in_trash` serialization on `2026-03-11` for pages and blocks, a two-clients-with-different-versions interleaving test asserting each client's payloads independently, and `append()` position tests for both versions.
- Every pre-existing serialization test (including the `archived` handling from #67 and the `initial_data_source` gate) passes unmodified, pinning byte-identical behaviour for clients that do not opt in.
- Verified against the live Notion API with two clients in one process: a `2026-03-11` client retrieved a block (response carries only `in_trash`), trashed it via `in_trash`, a `2022-06-28` client restored it via `archived`, and both `after` and `position.after_block` insertions were accepted on their respective versions.
- Full suite green (161 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
