### PR TITLE
feat(blocks): support tab, meeting notes, and transcription blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `NOTION_VERSION_2022_06_28`, `NOTION_VERSION_2025_09_03`, and `NOTION_VERSION_2026_03_11` constants on `ClientOptions`; the default version is unchanged.
 - Add `isInTrash()`/`setInTrash()` on `Page`, blocks, and `Database`, and accept both the `archived` and `in_trash` response keys during hydration — including for data sources — regardless of the client version.
 - Add an optional `$afterBlockId` parameter to `blocks()->children()->append()` to insert blocks after an existing block.
+- Add `tab`, `meeting_notes`, and `transcription` block classes so these blocks hydrate with their content instead of degrading to `UnsupportedBlock` and dropping the payload. Meeting notes and transcription blocks are read-only at the API; tab blocks are creatable, with the label carried by paragraph children.
 - Add markdown page content support (Notion API `2026-03-11`): `pages()->createFromMarkdown()`, `retrieveMarkdown()`, and `updateMarkdown()` with a `PageMarkdownRequest` builder covering the `update_content`, `replace_content`, `insert_content`, and `replace_content_range` commands.
 - Add async-task support for long markdown operations: `createFromMarkdownAsync()`/`updateMarkdownAsync()` return an `AsyncTask` to poll via the new `$notion->asyncTasks()->retrieve()`.
 

--- a/src/Resource/Block/MeetingNotesBlock.php
+++ b/src/Resource/Block/MeetingNotesBlock.php
@@ -8,18 +8,12 @@ use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
 use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
 use Brd6\NotionSdkPhp\Resource\Property\MeetingNotesProperty;
 
-/**
- * Meeting notes blocks are read-only at the Notion API: they hydrate from
- * responses but cannot be created or updated.
- */
 class MeetingNotesBlock extends AbstractBlock
 {
     protected ?MeetingNotesProperty $meetingNotes = null;
 
     /**
-     * The payload's `children` key holds block-id references (summary, notes,
-     * transcript), not inline child blocks; fetch actual children through
-     * blocks()->children()->list().
+     * The payload's `children` key holds block-id references, not inline child blocks.
      */
     protected function initializeChildren(): void
     {

--- a/src/Resource/Block/MeetingNotesBlock.php
+++ b/src/Resource/Block/MeetingNotesBlock.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Resource\Property\MeetingNotesProperty;
+
+/**
+ * Meeting notes blocks are read-only at the Notion API: they hydrate from
+ * responses but cannot be created or updated.
+ */
+class MeetingNotesBlock extends AbstractBlock
+{
+    protected ?MeetingNotesProperty $meetingNotes = null;
+
+    /**
+     * The payload's `children` key holds block-id references (summary, notes,
+     * transcript), not inline child blocks; fetch actual children through
+     * blocks()->children()->list().
+     */
+    protected function initializeChildren(): void
+    {
+    }
+
+    /**
+     * @throws InvalidRichTextException
+     * @throws UnsupportedRichTextTypeException
+     */
+    protected function initializeBlockProperty(): void
+    {
+        $data = (array) $this->getRawData()[$this->getType()];
+        $this->meetingNotes = MeetingNotesProperty::fromRawData($data);
+    }
+
+    public function getMeetingNotes(): ?MeetingNotesProperty
+    {
+        return $this->meetingNotes;
+    }
+
+    public function setMeetingNotes(?MeetingNotesProperty $meetingNotes): self
+    {
+        $this->meetingNotes = $meetingNotes;
+
+        return $this;
+    }
+}

--- a/src/Resource/Block/TabBlock.php
+++ b/src/Resource/Block/TabBlock.php
@@ -6,10 +6,6 @@ namespace Brd6\NotionSdkPhp\Resource\Block;
 
 use Brd6\NotionSdkPhp\Resource\Property\TabProperty;
 
-/**
- * The tab payload is an empty object: a tab's label and content are expressed
- * through its paragraph children.
- */
 class TabBlock extends AbstractBlock
 {
     protected ?TabProperty $tab = null;

--- a/src/Resource/Block/TabBlock.php
+++ b/src/Resource/Block/TabBlock.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Resource\Property\TabProperty;
+
+/**
+ * The tab payload is an empty object: a tab's label and content are expressed
+ * through its paragraph children.
+ */
+class TabBlock extends AbstractBlock
+{
+    protected ?TabProperty $tab = null;
+
+    protected function initializeBlockProperty(): void
+    {
+        $data = (array) $this->getRawData()[$this->getType()];
+        $this->tab = TabProperty::fromRawData($data);
+    }
+
+    public function getTab(): ?TabProperty
+    {
+        return $this->tab;
+    }
+
+    public function setTab(?TabProperty $tab): self
+    {
+        $this->tab = $tab;
+
+        return $this;
+    }
+}

--- a/src/Resource/Block/TranscriptionBlock.php
+++ b/src/Resource/Block/TranscriptionBlock.php
@@ -8,19 +8,12 @@ use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
 use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
 use Brd6\NotionSdkPhp\Resource\Property\MeetingNotesProperty;
 
-/**
- * The pre-2026-03-11 name of the meeting notes block: responses on older API
- * versions carry `transcription` with the same payload shape. Read-only at
- * the Notion API.
- */
 class TranscriptionBlock extends AbstractBlock
 {
     protected ?MeetingNotesProperty $transcription = null;
 
     /**
-     * The payload's `children` key holds block-id references (summary, notes,
-     * transcript), not inline child blocks; fetch actual children through
-     * blocks()->children()->list().
+     * The payload's `children` key holds block-id references, not inline child blocks.
      */
     protected function initializeChildren(): void
     {

--- a/src/Resource/Block/TranscriptionBlock.php
+++ b/src/Resource/Block/TranscriptionBlock.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Resource\Property\MeetingNotesProperty;
+
+/**
+ * The pre-2026-03-11 name of the meeting notes block: responses on older API
+ * versions carry `transcription` with the same payload shape. Read-only at
+ * the Notion API.
+ */
+class TranscriptionBlock extends AbstractBlock
+{
+    protected ?MeetingNotesProperty $transcription = null;
+
+    /**
+     * The payload's `children` key holds block-id references (summary, notes,
+     * transcript), not inline child blocks; fetch actual children through
+     * blocks()->children()->list().
+     */
+    protected function initializeChildren(): void
+    {
+    }
+
+    /**
+     * @throws InvalidRichTextException
+     * @throws UnsupportedRichTextTypeException
+     */
+    protected function initializeBlockProperty(): void
+    {
+        $data = (array) $this->getRawData()[$this->getType()];
+        $this->transcription = MeetingNotesProperty::fromRawData($data);
+    }
+
+    public function getTranscription(): ?MeetingNotesProperty
+    {
+        return $this->transcription;
+    }
+
+    public function setTranscription(?MeetingNotesProperty $transcription): self
+    {
+        $this->transcription = $transcription;
+
+        return $this;
+    }
+}

--- a/src/Resource/Property/MeetingNotesProperty.php
+++ b/src/Resource/Property/MeetingNotesProperty.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Property;
+
+use Brd6\NotionSdkPhp\Exception\InvalidRichTextException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedRichTextTypeException;
+use Brd6\NotionSdkPhp\Resource\RichText\AbstractRichText;
+
+use function array_map;
+
+class MeetingNotesProperty extends AbstractProperty
+{
+    public const STATUS_TRANSCRIPTION_NOT_STARTED = 'transcription_not_started';
+    public const STATUS_TRANSCRIPTION_PAUSED = 'transcription_paused';
+    public const STATUS_TRANSCRIPTION_IN_PROGRESS = 'transcription_in_progress';
+    public const STATUS_TRANSCRIPTION_FAILED = 'transcription_failed';
+    public const STATUS_SUMMARY_IN_PROGRESS = 'summary_in_progress';
+    public const STATUS_NOTES_READY = 'notes_ready';
+
+    /**
+     * @var array|AbstractRichText[]
+     */
+    protected array $title = [];
+    protected string $status = '';
+    protected array $children = [];
+    protected array $calendarEvent = [];
+    protected array $recording = [];
+
+    /**
+     * @param array $rawData
+     *
+     * @return MeetingNotesProperty
+     *
+     * @throws InvalidRichTextException
+     * @throws UnsupportedRichTextTypeException
+     */
+    public static function fromRawData(array $rawData): self
+    {
+        $property = new self();
+
+        $property->title = isset($rawData['title']) ? array_map(
+            fn (array $richTextRawData) => AbstractRichText::fromRawData($richTextRawData),
+            (array) $rawData['title'],
+        ) : [];
+        $property->status = (string) ($rawData['status'] ?? '');
+        $property->children = (array) ($rawData['children'] ?? []);
+        $property->calendarEvent = (array) ($rawData['calendar_event'] ?? []);
+        $property->recording = (array) ($rawData['recording'] ?? []);
+
+        return $property;
+    }
+
+    /**
+     * @return array|AbstractRichText[]
+     */
+    public function getTitle(): array
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param array|AbstractRichText[] $title
+     */
+    public function setTitle(array $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function setChildren(array $children): self
+    {
+        $this->children = $children;
+
+        return $this;
+    }
+
+    public function getCalendarEvent(): array
+    {
+        return $this->calendarEvent;
+    }
+
+    public function setCalendarEvent(array $calendarEvent): self
+    {
+        $this->calendarEvent = $calendarEvent;
+
+        return $this;
+    }
+
+    public function getRecording(): array
+    {
+        return $this->recording;
+    }
+
+    public function setRecording(array $recording): self
+    {
+        $this->recording = $recording;
+
+        return $this;
+    }
+}

--- a/src/Resource/Property/TabProperty.php
+++ b/src/Resource/Property/TabProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Property;
+
+class TabProperty extends AbstractProperty
+{
+    public static function fromRawData(array $rawData): self
+    {
+        return new self();
+    }
+}

--- a/tests/Fixtures/client_blocks_retrieve_block_meeting_notes_200.json
+++ b/tests/Fixtures/client_blocks_retrieve_block_meeting_notes_200.json
@@ -1,0 +1,60 @@
+{
+    "object": "block",
+    "id": "8c1f3a52-9d47-4b8e-a316-72e05c4d9b83",
+    "parent": {
+        "type": "page_id",
+        "page_id": "b55c9c91-384d-452b-81db-d1ef79372b75"
+    },
+    "created_time": "2026-07-14T11:39:00.000Z",
+    "last_edited_time": "2026-07-14T11:52:00.000Z",
+    "created_by": {
+        "object": "user",
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+    },
+    "last_edited_by": {
+        "object": "user",
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+    },
+    "has_children": true,
+    "archived": false,
+    "in_trash": false,
+    "type": "meeting_notes",
+    "meeting_notes": {
+        "title": [
+            {
+                "type": "text",
+                "text": {
+                    "content": "Weekly sync",
+                    "link": null
+                },
+                "annotations": {
+                    "bold": false,
+                    "italic": false,
+                    "strikethrough": false,
+                    "underline": false,
+                    "code": false,
+                    "color": "default"
+                },
+                "plain_text": "Weekly sync",
+                "href": null
+            }
+        ],
+        "status": "notes_ready",
+        "children": {
+            "summary_block_id": "0d940186-ab70-4351-bb34-2d16f0635d50",
+            "notes_block_id": "1e940186-ab70-4351-bb34-2d16f0635d51",
+            "transcript_block_id": "2f940186-ab70-4351-bb34-2d16f0635d52"
+        },
+        "calendar_event": {
+            "start_time": "2026-07-14T10:00:00.000Z",
+            "end_time": "2026-07-14T10:30:00.000Z",
+            "attendees": [
+                "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+            ]
+        },
+        "recording": {
+            "start_time": "2026-07-14T10:00:12.000Z",
+            "end_time": "2026-07-14T10:29:48.000Z"
+        }
+    }
+}

--- a/tests/Fixtures/client_blocks_retrieve_block_tab_200.json
+++ b/tests/Fixtures/client_blocks_retrieve_block_tab_200.json
@@ -1,0 +1,23 @@
+{
+    "object": "block",
+    "id": "5b56b5c7-2c3c-4e6a-92dd-14b1cf9a6621",
+    "parent": {
+        "type": "page_id",
+        "page_id": "b55c9c91-384d-452b-81db-d1ef79372b75"
+    },
+    "created_time": "2026-07-14T11:39:00.000Z",
+    "last_edited_time": "2026-07-14T11:39:00.000Z",
+    "created_by": {
+        "object": "user",
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+    },
+    "last_edited_by": {
+        "object": "user",
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+    },
+    "has_children": true,
+    "archived": false,
+    "in_trash": false,
+    "type": "tab",
+    "tab": {}
+}

--- a/tests/Fixtures/client_blocks_retrieve_block_transcription_200.json
+++ b/tests/Fixtures/client_blocks_retrieve_block_transcription_200.json
@@ -1,0 +1,60 @@
+{
+    "object": "block",
+    "id": "9e2a4b63-0f58-4c9d-b427-83f16d5e0c94",
+    "parent": {
+        "type": "page_id",
+        "page_id": "b55c9c91-384d-452b-81db-d1ef79372b75"
+    },
+    "created_time": "2026-07-14T11:39:00.000Z",
+    "last_edited_time": "2026-07-14T11:52:00.000Z",
+    "created_by": {
+        "object": "user",
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+    },
+    "last_edited_by": {
+        "object": "user",
+        "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+    },
+    "has_children": true,
+    "archived": false,
+    "in_trash": false,
+    "type": "transcription",
+    "transcription": {
+        "title": [
+            {
+                "type": "text",
+                "text": {
+                    "content": "Weekly sync",
+                    "link": null
+                },
+                "annotations": {
+                    "bold": false,
+                    "italic": false,
+                    "strikethrough": false,
+                    "underline": false,
+                    "code": false,
+                    "color": "default"
+                },
+                "plain_text": "Weekly sync",
+                "href": null
+            }
+        ],
+        "status": "transcription_in_progress",
+        "children": {
+            "summary_block_id": "0d940186-ab70-4351-bb34-2d16f0635d50",
+            "notes_block_id": "1e940186-ab70-4351-bb34-2d16f0635d51",
+            "transcript_block_id": "2f940186-ab70-4351-bb34-2d16f0635d52"
+        },
+        "calendar_event": {
+            "start_time": "2026-07-14T10:00:00.000Z",
+            "end_time": "2026-07-14T10:30:00.000Z",
+            "attendees": [
+                "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+            ]
+        },
+        "recording": {
+            "start_time": "2026-07-14T10:00:12.000Z",
+            "end_time": "2026-07-14T10:29:48.000Z"
+        }
+    }
+}

--- a/tests/Resource/BlockTest.php
+++ b/tests/Resource/BlockTest.php
@@ -17,8 +17,11 @@ use Brd6\NotionSdkPhp\Resource\Block\Heading3Block;
 use Brd6\NotionSdkPhp\Resource\Block\Heading4Block;
 use Brd6\NotionSdkPhp\Resource\Block\Heading5Block;
 use Brd6\NotionSdkPhp\Resource\Block\Heading6Block;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ParagraphBlock;
 use Brd6\NotionSdkPhp\Resource\Block\SyncedBlockBlock;
+use Brd6\NotionSdkPhp\Resource\Block\TabBlock;
+use Brd6\NotionSdkPhp\Resource\Block\TranscriptionBlock;
 use Brd6\NotionSdkPhp\Resource\Block\UnsupportedBlock;
 use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
 use Brd6\NotionSdkPhp\Resource\File\Emoji;
@@ -26,8 +29,10 @@ use Brd6\NotionSdkPhp\Resource\Property\CalloutProperty;
 use Brd6\NotionSdkPhp\Resource\Property\ChildPageProperty;
 use Brd6\NotionSdkPhp\Resource\Property\FileProperty;
 use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
+use Brd6\NotionSdkPhp\Resource\Property\MeetingNotesProperty;
 use Brd6\NotionSdkPhp\Resource\Property\ParagraphProperty;
 use Brd6\NotionSdkPhp\Resource\Property\SyncedBlockProperty;
+use Brd6\NotionSdkPhp\Resource\Property\TabProperty;
 use Brd6\NotionSdkPhp\Resource\RichText\Equation;
 use Brd6\NotionSdkPhp\Resource\RichText\Mention;
 use Brd6\NotionSdkPhp\Resource\RichText\Mention\CustomEmojiMention;
@@ -499,5 +504,68 @@ class BlockTest extends TestCase
 
         $this->assertTrue($block->isArchived());
         $this->assertTrue($block->isInTrash());
+    }
+
+    public function testTabBlock(): void
+    {
+        $block = AbstractBlock::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_tab_200.json'),
+                true,
+            ),
+        );
+
+        $this->assertInstanceOf(TabBlock::class, $block);
+        $this->assertEquals('tab', $block->getType());
+        $this->assertInstanceOf(TabProperty::class, $block->getTab());
+        $this->assertTrue($block->isHasChildren());
+    }
+
+    public function testTabBlockSerialization(): void
+    {
+        $block = new TabBlock();
+        $block->setTab(new TabProperty());
+
+        $this->assertEquals('tab', $block->toArrayForCreate()['type']);
+    }
+
+    public function testMeetingNotesBlock(): void
+    {
+        $block = AbstractBlock::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_meeting_notes_200.json'),
+                true,
+            ),
+        );
+
+        $this->assertInstanceOf(MeetingNotesBlock::class, $block);
+        $this->assertEquals('meeting_notes', $block->getType());
+
+        $property = $block->getMeetingNotes();
+        $this->assertInstanceOf(MeetingNotesProperty::class, $property);
+        $this->assertEquals('notes_ready', $property->getStatus());
+        $this->assertInstanceOf(Text::class, $property->getTitle()[0]);
+        $this->assertEquals('Weekly sync', $property->getTitle()[0]->getText()->getContent());
+        $this->assertEquals('0d940186-ab70-4351-bb34-2d16f0635d50', $property->getChildren()['summary_block_id']);
+        $this->assertNotEmpty($property->getCalendarEvent()['attendees']);
+        $this->assertNotEmpty($property->getRecording()['start_time']);
+    }
+
+    public function testTranscriptionBlock(): void
+    {
+        $block = AbstractBlock::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_blocks_retrieve_block_transcription_200.json'),
+                true,
+            ),
+        );
+
+        $this->assertInstanceOf(TranscriptionBlock::class, $block);
+        $this->assertEquals('transcription', $block->getType());
+
+        $property = $block->getTranscription();
+        $this->assertInstanceOf(MeetingNotesProperty::class, $property);
+        $this->assertEquals(MeetingNotesProperty::STATUS_TRANSCRIPTION_IN_PROGRESS, $property->getStatus());
+        $this->assertEquals('Weekly sync', $property->getTitle()[0]->getText()->getContent());
     }
 }


### PR DESCRIPTION
## Description

Adds three block types that previously degraded to `UnsupportedBlock`, silently dropping their payloads:

- `TabBlock` + `TabProperty` — the payload is an empty object; a tab's label and content are expressed through its paragraph children. Creatable via `blocks()->children()->append()`.
- `MeetingNotesBlock` — read-only at the API; hydrates `title` (rich text), `status` (six documented values as constants), the `children` block-id references (summary/notes/transcript), `calendar_event`, and `recording`.
- `TranscriptionBlock` — the pre-`2026-03-11` name for the same payload; both classes share one `MeetingNotesProperty`, the same way the six heading blocks share `HeadingProperty`. Both payload shapes hydrate regardless of the client's API version, since the response names its own block type.

One structural note: the `children` key inside these payloads holds block-id references, not inline child blocks, so the generic nested-children hydration is bypassed for these two types (it would fail on the reference map); actual children remain fetchable through `blocks()->children()->list()`.

## Motivation and context

Notion returns these block types on pages with tabs and AI meeting notes. An SDK consumer reading such a page currently gets an `UnsupportedBlock` with no payload — the same failure mode the `heading_4` gap produced before 1.9.0.

## How has this been tested?

- New `BlockTest` cases: each type hydrates to its class with populated properties (previously `UnsupportedBlock`), including the meeting-notes status/title/references/calendar/recording fields, plus tab create serialization.
- Verified live against the Notion API: a tab block with a paragraph label was created through the SDK, retrieved back as a `TabBlock` with `has_children: true`, and deleted. Meeting notes and transcription blocks cannot be created via the API (read-only, produced only by Notion meeting recordings), so their fixtures follow the official block reference shapes.
- Full suite green (180 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
