### PR TITLE
feat(databases): complete Notion API 2025-09-03 data-source coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add an optional `$afterBlockId` parameter to `blocks()->children()->append()` to insert blocks after an existing block.
 - Add markdown page content support (Notion API `2026-03-11`): `pages()->createFromMarkdown()`, `retrieveMarkdown()`, and `updateMarkdown()` with a `PageMarkdownRequest` builder covering the `update_content`, `replace_content`, `insert_content`, and `replace_content_range` commands.
 - Add async-task support for long markdown operations: `createFromMarkdownAsync()`/`updateMarkdownAsync()` return an `AsyncTask` to poll via the new `$notion->asyncTasks()->retrieve()`.
+- Add `FILTER_VALUE_PAGE`, `FILTER_VALUE_DATA_SOURCE`, and legacy `FILTER_VALUE_DATABASE` constants on `SearchRequest` for the search filter values.
 
 ### Changed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `databases()->update()` on Notion API `2025-09-03` or newer no longer sends `properties` (schema changes moved to `dataSources()->update()`) and omits unset `icon`/`cover`, which that version rejects as explicit nulls. Payloads on older versions are unchanged.
 - Blocks sent as children in `blocks()->children()->append()` and `pages()->create()` now serialize only creatable fields (`object`, `type`, and the block's own property) via `AbstractBlock::toArrayForCreate()`. The Notion API rejects payloads carrying read-only fields such as `archived` with a validation error.
 - Nested blocks set with `setChildren()` now serialize inside the block's type property — the only shape the Notion API accepts — and recursively emit only creatable fields, so appending a block with nested children works instead of failing validation.
 

--- a/src/Endpoint/DatabasesEndpoint.php
+++ b/src/Endpoint/DatabasesEndpoint.php
@@ -102,10 +102,26 @@ class DatabasesEndpoint extends AbstractEndpoint
      */
     public function update(Database $database): Database
     {
+        $data = $database->toArrayForUpdate();
+
+        if ($this->supportsVersion(ClientOptions::NOTION_VERSION_2025_09_03)) {
+            // Schema changes moved to Update Data Source on 2025-09-03: use dataSources()->update().
+            unset($data['properties']);
+
+            // 2025-09-03 rejects explicit nulls for icon and cover; older versions accept them.
+            if (($data['icon'] ?? null) === null) {
+                unset($data['icon']);
+            }
+
+            if (($data['cover'] ?? null) === null) {
+                unset($data['cover']);
+            }
+        }
+
         $requestParameters = (new RequestParameters())
             ->setPath("databases/{$database->getId()}")
             ->setMethod('PATCH')
-            ->setBody($this->normalizeTrashKey($database->toArrayForUpdate()));
+            ->setBody($this->normalizeTrashKey($data));
 
         $rawData = $this->getClient()->request($requestParameters);
 

--- a/src/Resource/Search/SearchRequest.php
+++ b/src/Resource/Search/SearchRequest.php
@@ -8,6 +8,14 @@ use Brd6\NotionSdkPhp\Resource\AbstractJsonSerializable;
 
 class SearchRequest extends AbstractJsonSerializable
 {
+    public const FILTER_VALUE_PAGE = 'page';
+    public const FILTER_VALUE_DATA_SOURCE = 'data_source';
+
+    /**
+     * Pre-2025-09-03 filter value; on newer API versions use FILTER_VALUE_DATA_SOURCE.
+     */
+    public const FILTER_VALUE_DATABASE = 'database';
+
     protected array $filter = [];
     protected array $sort = [];
     protected ?string $query = null;

--- a/tests/Endpoint/DatabasesEndpointTest.php
+++ b/tests/Endpoint/DatabasesEndpointTest.php
@@ -416,4 +416,42 @@ class DatabasesEndpointTest extends TestCase
         $this->assertNotEmpty($database->getId());
         $this->assertNotEmpty($database->getProperties());
     }
+
+    public function testUpdateDatabaseWith2025VersionDropsProperties(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('title', $body);
+            $this->assertArrayNotHasKey('properties', $body);
+            $this->assertArrayNotHasKey('icon', $body);
+            $this->assertArrayNotHasKey('cover', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_databases_update_database_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2025_09_03)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $database = new Database();
+        $database->setId('c5a8c1b2-8a71-4e92-a8c9-26d6b00738fe');
+        $database->setTitle([Text::fromContent('Database new title!')]);
+
+        $inStockSelectObject = new SelectPropertyObject();
+        $inStockSelectObject->setSelect(
+            (new SelectPropertyConfiguration())->setOptions([
+                (new SelectProperty())->setName('Yes')->setColor('green'),
+            ]),
+        );
+        $database->setProperties(['in stock' => $inStockSelectObject]);
+
+        $client->databases()->update($database);
+    }
 }

--- a/tests/Endpoint/SearchEndpointTest.php
+++ b/tests/Endpoint/SearchEndpointTest.php
@@ -125,7 +125,7 @@ class SearchEndpointTest extends TestCase
         $client = new Client((new ClientOptions())->setHttpClient($httpClient));
         $searchRequest = (new SearchRequest())->setFilter([
             'property' => 'object',
-            'value' => 'data_source',
+            'value' => SearchRequest::FILTER_VALUE_DATA_SOURCE,
         ]);
 
         /** @var PageOrDatabaseResults $results */
@@ -167,5 +167,12 @@ class SearchEndpointTest extends TestCase
         $this->assertInstanceOf(Page::class, $resultPage);
         $this->assertInstanceOf(BlockIdParent::class, $parent);
         $this->assertSame($blockId, $parent->getBlockId());
+    }
+
+    public function testSearchFilterValueConstants(): void
+    {
+        $this->assertEquals('page', SearchRequest::FILTER_VALUE_PAGE);
+        $this->assertEquals('data_source', SearchRequest::FILTER_VALUE_DATA_SOURCE);
+        $this->assertEquals('database', SearchRequest::FILTER_VALUE_DATABASE);
     }
 }


### PR DESCRIPTION
## Description

Completes the SDK's correctness on Notion API `2025-09-03`, where schema changes moved from the database to the data source:

- `databases()->update()` on `2025-09-03` or newer no longer sends `properties` — that version's `PATCH /v1/databases` is database-only, and schema changes belong to `dataSources()->update()`. It also omits unset `icon`/`cover`, which that version rejects as explicit nulls (`body.icon should be an object or undefined`). Older versions send byte-identical payloads to before.
- `SearchRequest` gains `FILTER_VALUE_PAGE` and `FILTER_VALUE_DATA_SOURCE` constants, plus the legacy `FILTER_VALUE_DATABASE` used by older API versions, so callers stop passing bare strings for the search filter.
- `RelationPropertyConfiguration` was audited against the `2025-09-03` requirement that relations are created with `data_source_id`: it already hydrates, exposes, and serializes `data_source_id` end to end, so no change was needed.

## Motivation and context

An integration raising its API version to `2025-09-03` (required once any of its databases gains a second data source) currently hits validation errors on `databases()->update()`: the API rejects both the moved `properties` key and the explicit null `icon`/`cover` the update payload carries.

## How has this been tested?

- New tests: `databases()->update()` on a `2025-09-03` client sends no `properties`/`icon`/`cover` keys; the pre-existing update test pins the unchanged default-version payload; the filter-value constants are asserted and used in the data-source search test.
- Verified live against the Notion API with a `2025-09-03` client: updating a real database with `properties` set (and no icon/cover) previously failed with the validation errors above and now succeeds with the schema intact, and searching with `FILTER_VALUE_DATA_SOURCE` returns hydrated `DataSource` results.
- Full suite green (178 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
