### PR TITLE
feat(blocks): support file-upload embeds for HTML blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add file-upload embeds: `EmbedProperty::fromFileUpload()` attaches an uploaded file to an embed block, which is how the Notion API renders uploaded `.html` files as HTML blocks. Responses hydrate the temporary signed `url` the API returns.
 - Add per-request headers and raw (non-JSON) request bodies to `RequestParameters`, unblocking `multipart/form-data` endpoints such as the Notion File Upload API.
 - Add `php-http/multipart-stream-builder` as a dependency for building multipart request bodies.
 - Add support for the Notion File Upload API via `$notion->fileUploads()`: a one-call `upload()` for the common case, plus create, send/sendPart (`multipart/form-data`), complete, retrieve, and list.

--- a/src/Resource/Property/EmbedProperty.php
+++ b/src/Resource/Property/EmbedProperty.php
@@ -6,13 +6,36 @@ namespace Brd6\NotionSdkPhp\Resource\Property;
 
 class EmbedProperty extends AbstractProperty
 {
+    public const TYPE_FILE_UPLOAD = 'file_upload';
+
     protected string $url = '';
+    protected ?string $type = null;
+    protected ?FileUploadProperty $fileUpload = null;
+
+    /**
+     * Embeds an uploaded file — for example an uploaded .html file, which Notion
+     * renders as an HTML block. Responses always carry a temporary signed `url`
+     * instead of the `file_upload` reference.
+     */
+    public static function fromFileUpload(string $fileUploadId): self
+    {
+        $property = new self();
+
+        $property->type = self::TYPE_FILE_UPLOAD;
+        $property->fileUpload = (new FileUploadProperty())->setId($fileUploadId);
+
+        return $property;
+    }
 
     public static function fromRawData(array $rawData): self
     {
         $property = new self();
 
-        $property->url = (string) $rawData['url'];
+        $property->url = (string) ($rawData['url'] ?? '');
+        $property->type = isset($rawData['type']) ? (string) $rawData['type'] : null;
+        $property->fileUpload = isset($rawData['file_upload']) ?
+            FileUploadProperty::fromRawData((array) $rawData['file_upload']) :
+            null;
 
         return $property;
     }
@@ -25,6 +48,30 @@ class EmbedProperty extends AbstractProperty
     public function setUrl(string $url): self
     {
         $this->url = $url;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getFileUpload(): ?FileUploadProperty
+    {
+        return $this->fileUpload;
+    }
+
+    public function setFileUpload(?FileUploadProperty $fileUpload): self
+    {
+        $this->fileUpload = $fileUpload;
 
         return $this;
     }

--- a/tests/Resource/Property/EmbedPropertyTest.php
+++ b/tests/Resource/Property/EmbedPropertyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource\Property;
+
+use Brd6\NotionSdkPhp\Resource\Block\EmbedBlock;
+use Brd6\NotionSdkPhp\Resource\Property\EmbedProperty;
+use Brd6\NotionSdkPhp\Resource\Property\FileUploadProperty;
+use PHPUnit\Framework\TestCase;
+
+class EmbedPropertyTest extends TestCase
+{
+    public function testFromFileUpload(): void
+    {
+        $property = EmbedProperty::fromFileUpload('43833259-72ae-404e-8441-b6577f3159b4');
+
+        $this->assertEquals(EmbedProperty::TYPE_FILE_UPLOAD, $property->getType());
+        $this->assertInstanceOf(FileUploadProperty::class, $property->getFileUpload());
+        $this->assertEquals('43833259-72ae-404e-8441-b6577f3159b4', $property->getFileUpload()->getId());
+    }
+
+    public function testFileUploadEmbedSerializesForCreate(): void
+    {
+        $block = new EmbedBlock();
+        $block->setEmbed(EmbedProperty::fromFileUpload('43833259-72ae-404e-8441-b6577f3159b4'));
+
+        $this->assertEquals([
+            'object' => 'block',
+            'type' => 'embed',
+            'embed' => [
+                'type' => 'file_upload',
+                'file_upload' => [
+                    'id' => '43833259-72ae-404e-8441-b6577f3159b4',
+                ],
+            ],
+        ], $block->toArrayForCreate());
+    }
+
+    public function testUrlEmbedSerializationUnchanged(): void
+    {
+        $block = new EmbedBlock();
+        $block->setEmbed((new EmbedProperty())->setUrl('https://example.com'));
+
+        $this->assertEquals([
+            'object' => 'block',
+            'type' => 'embed',
+            'embed' => [
+                'url' => 'https://example.com',
+            ],
+        ], $block->toArrayForCreate());
+    }
+
+    public function testFromRawDataWithUrl(): void
+    {
+        $property = EmbedProperty::fromRawData(['url' => 'https://example.com']);
+
+        $this->assertEquals('https://example.com', $property->getUrl());
+        $this->assertNull($property->getType());
+        $this->assertNull($property->getFileUpload());
+    }
+
+    public function testFromRawDataWithoutUrl(): void
+    {
+        $property = EmbedProperty::fromRawData([
+            'type' => 'file_upload',
+            'file_upload' => ['id' => '43833259-72ae-404e-8441-b6577f3159b4'],
+        ]);
+
+        $this->assertEquals('', $property->getUrl());
+        $this->assertEquals('file_upload', $property->getType());
+        $this->assertEquals('43833259-72ae-404e-8441-b6577f3159b4', $property->getFileUpload()->getId());
+    }
+}


### PR DESCRIPTION
## Description

Adds file-upload embeds, which is how the Notion API supports [HTML blocks](https://developers.notion.com/reference/block#html-blocks): uploading an `.html` file and attaching it to an embed block.

- `EmbedProperty::fromFileUpload($fileUploadId)` builds the documented `{type: "file_upload", file_upload: {id}}` payload; combined with the file-upload API this makes an HTML block two calls:

```php
$upload = $notion->fileUploads()->upload($html, 'page.html');
$embed = (new EmbedBlock())->setEmbed(EmbedProperty::fromFileUpload($upload->getId()));
$notion->blocks()->children()->append($pageId, [$embed]);
```

- Hydration accepts the `type` and `file_upload` keys and guards the `url` read (responses carry a temporary signed `url` instead of the `file_upload` reference, per the docs).
- URL embeds are untouched: an `EmbedProperty` with only a `url` serializes exactly as before, pinned by a test.

## Motivation and context

The July 2026 API changelog added HTML block creation via the File Upload API. The SDK's `EmbedProperty` only modeled `url`, so the documented `embed.file_upload` shape could not be expressed, and hydrating an embed payload without a `url` key raised an undefined-key warning.

## How has this been tested?

- New `EmbedPropertyTest`: the `fromFileUpload()` payload shape, byte-exact create serialization for both embed variants, and hydration with and without the `url` key.
- Verified live against the Notion API: uploaded a real `.html` file through `fileUploads()->upload()`, appended an embed block referencing it, and read the block back with the signed URL the API returns.
- Full suite green (181 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
