### PR TITLE
fix(parent): support agent_id page parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Add support for `agent_id` page parents so pages parented to a Notion agent hydrate instead of throwing `UnsupportedParentTypeException`.
+
 ## 1.10.0 - 2026-07-14
 
 ### Added

--- a/src/Resource/Page/Parent/AgentIdParent.php
+++ b/src/Resource/Page/Parent/AgentIdParent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Page\Parent;
+
+class AgentIdParent extends AbstractParentProperty
+{
+    protected string $agentId = '';
+
+    public function __construct()
+    {
+        $this->type = 'agent_id';
+    }
+
+    protected function initialize(): void
+    {
+        $this->agentId = (string) $this->getRawData()['agent_id'];
+    }
+
+    public function getAgentId(): string
+    {
+        return $this->agentId;
+    }
+
+    public function setAgentId(string $agentId): self
+    {
+        $this->agentId = $agentId;
+
+        return $this;
+    }
+}

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -9,6 +9,7 @@ use Brd6\NotionSdkPhp\Resource\File\Emoji;
 use Brd6\NotionSdkPhp\Resource\File\External;
 use Brd6\NotionSdkPhp\Resource\File\Icon;
 use Brd6\NotionSdkPhp\Resource\Page;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\AgentIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\BlockIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\DatabaseIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\NumberPropertyValue;
@@ -124,6 +125,29 @@ class PageTest extends TestCase
 
         $this->assertInstanceOf(BlockIdParent::class, $parent);
         $this->assertSame($blockId, $parent->getBlockId());
+    }
+
+    public function testPageWithAgentIdParent(): void
+    {
+        $agentId = '8e61b295-6ccf-4e01-9f3a-7cfd68fe928c';
+
+        /** @var array $rawData */
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+            true,
+        );
+        $rawData['parent'] = [
+            'type' => 'agent_id',
+            'agent_id' => $agentId,
+        ];
+
+        /** @var Page $page */
+        $page = Page::fromRawData($rawData);
+
+        $parent = $page->getParent();
+
+        $this->assertInstanceOf(AgentIdParent::class, $parent);
+        $this->assertSame($agentId, $parent->getAgentId());
     }
 
     public function testPageHydratesInTrashPayloadWithoutArchivedKey(): void


### PR DESCRIPTION
## Description

Adds `AgentIdParent` so pages parented to a Notion agent hydrate instead of throwing. The May 2026 API changelog added the `agent_id` parent type (`{"type": "agent_id", "agent_id": "<uuid>"}`) for agent instruction pages; the SDK's convention-based parent resolution had no matching class, so retrieving or searching across such a page threw `UnsupportedParentTypeException` — the same failure mode `block_id` parents had before 1.8.3.

## Motivation and context

Any consumer whose workspace uses Notion agents hits this on read paths (page retrieve, search, block hydration) with no workaround, since hydration happens before the consumer sees the payload.

## How has this been tested?

- New test hydrating a page whose parent is `agent_id` — previously threw `UnsupportedParentTypeException`, now yields an `AgentIdParent` exposing the agent id. Agent-parented pages cannot be created via the API, so the fixture-based hydration path is the consumer-facing surface.
- Full suite green (188 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
