### PR TITLE
feat(blocks): expose the underlying block type on unsupported blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Expose `block_type` on `UnsupportedBlock`, identifying the underlying block type (for example `form` or `button`) the API cannot represent.
+
 ### Fixed
 
 - Add support for `agent_id` page parents so pages parented to a Notion agent hydrate instead of throwing `UnsupportedParentTypeException`.

--- a/src/Resource/Block/UnsupportedBlock.php
+++ b/src/Resource/Block/UnsupportedBlock.php
@@ -6,12 +6,30 @@ namespace Brd6\NotionSdkPhp\Resource\Block;
 
 class UnsupportedBlock extends AbstractBlock
 {
+    protected ?string $blockType = null;
+
     protected function initialize(): void
     {
         $this->type = (string) $this->getRawData()['type'];
+
+        $this->initializeBlockProperty();
     }
 
     protected function initializeBlockProperty(): void
     {
+        $data = (array) ($this->getRawData()['unsupported'] ?? []);
+        $this->blockType = isset($data['block_type']) ? (string) $data['block_type'] : null;
+    }
+
+    public function getBlockType(): ?string
+    {
+        return $this->blockType;
+    }
+
+    public function setBlockType(?string $blockType): self
+    {
+        $this->blockType = $blockType;
+
+        return $this;
     }
 }

--- a/tests/Resource/BlockTest.php
+++ b/tests/Resource/BlockTest.php
@@ -75,6 +75,34 @@ class BlockTest extends TestCase
         $this->assertEquals('unsupported_block', $block->getType());
     }
 
+    public function testUnsupportedBlockExposesBlockType(): void
+    {
+        /** @var UnsupportedBlock $block */
+        $block = AbstractBlock::fromRawData([
+            'object' => 'block',
+            'id' => 'c02fc1d3-db8b-45c5-a222-27595b15aea7',
+            'type' => 'unsupported',
+            'unsupported' => [
+                'block_type' => 'form',
+            ],
+        ]);
+
+        $this->assertInstanceOf(UnsupportedBlock::class, $block);
+        $this->assertEquals('unsupported', $block->getType());
+        $this->assertEquals('form', $block->getBlockType());
+    }
+
+    public function testUnknownBlockTypeHasNoBlockType(): void
+    {
+        /** @var UnsupportedBlock $block */
+        $block = AbstractBlock::fromRawData([
+            'object' => 'block',
+            'type' => 'unsupported_block',
+        ]);
+
+        $this->assertNull($block->getBlockType());
+    }
+
     public function testBlock(): void
     {
         $block = AbstractBlock::fromRawData(


### PR DESCRIPTION
## Description

`UnsupportedBlock` now exposes `getBlockType()`, hydrated from the `unsupported.block_type` field the API returns to identify the underlying block type (for example `form` or `button`). Unknown block types that fall back to `UnsupportedBlock` without that payload return `null`.

## Motivation and context

The March 2026 API changelog added `block_type` to unsupported blocks so consumers can tell what a block actually is — useful for graceful degradation (rendering a placeholder per type) instead of a generic unknown. The SDK hydrated the type string only and dropped the payload.

## How has this been tested?

- New tests: an `unsupported` payload carrying `block_type: form` exposes it; an unknown-type fallback exposes `null`.
- Full suite green (190 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
