### PR TITLE
feat(blocks): support querying meeting notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add `blocks()->queryMeetingNotes()` (Notion API `2026-03-11`) to search AI meeting notes across the workspace by title, attendees, dates, and editors, with sorting and a result limit — the endpoint has no cursor pagination.
+- Add `blocks()->meetingNotes()->query()` (Notion API `2026-03-11`) to search AI meeting notes across the workspace by title, attendees, dates, and editors, with sorting and a result limit — the endpoint has no cursor pagination.
 - Add comment editing (Notion API `2026-03-11`): `comments()->update()` and `updateFromMarkdown()` rewrite a comment's content, `delete()` removes it, and `createFromMarkdown()` writes a new comment as inline markdown. A connection can only edit comments it created.
 - Expose `block_type` on `UnsupportedBlock`, identifying the underlying block type (for example `form` or `button`) the API cannot represent.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `blocks()->queryMeetingNotes()` (Notion API `2026-03-11`) to search AI meeting notes across the workspace by title, attendees, dates, and editors, with sorting and a result limit — the endpoint has no cursor pagination.
 - Add comment editing (Notion API `2026-03-11`): `comments()->update()` and `updateFromMarkdown()` rewrite a comment's content, `delete()` removes it, and `createFromMarkdown()` writes a new comment as inline markdown. A connection can only edit comments it created.
 - Expose `block_type` on `UnsupportedBlock`, identifying the underlying block type (for example `form` or `button`) the API cannot represent.
 

--- a/src/Endpoint/BlocksEndpoint.php
+++ b/src/Endpoint/BlocksEndpoint.php
@@ -13,19 +13,19 @@ use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
 use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
 use Brd6\NotionSdkPhp\RequestParameters;
 use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
-use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryRequest;
-use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryResults;
 use Http\Client\Exception;
 
 class BlocksEndpoint extends AbstractEndpoint
 {
     private BlocksChildrenEndpoint $childrenEndpoint;
+    private BlocksMeetingNotesEndpoint $meetingNotesEndpoint;
 
     public function __construct(Client $client)
     {
         parent::__construct($client);
 
         $this->childrenEndpoint = new BlocksChildrenEndpoint($client);
+        $this->meetingNotesEndpoint = new BlocksMeetingNotesEndpoint($client);
     }
 
     /**
@@ -78,32 +78,14 @@ class BlocksEndpoint extends AbstractEndpoint
         return AbstractBlock::fromRawData($rawData);
     }
 
-    /**
-     * Queries AI meeting notes across the workspace. Requires Notion-Version 2026-03-11.
-     *
-     * @throws ApiResponseException
-     * @throws Exception
-     * @throws HttpResponseException
-     * @throws InvalidResourceException
-     * @throws InvalidResourceTypeException
-     * @throws RequestTimeoutException
-     * @throws UnsupportedUserTypeException
-     */
-    public function queryMeetingNotes(?MeetingNotesQueryRequest $queryRequest = null): MeetingNotesQueryResults
-    {
-        $requestParameters = (new RequestParameters())
-            ->setPath('blocks/meeting_notes/query')
-            ->setMethod('POST')
-            ->setBody($queryRequest ? $queryRequest->toArray() : []);
-
-        $rawData = $this->getClient()->request($requestParameters);
-
-        return MeetingNotesQueryResults::fromRawData($rawData);
-    }
-
     public function children(): BlocksChildrenEndpoint
     {
         return $this->childrenEndpoint;
+    }
+
+    public function meetingNotes(): BlocksMeetingNotesEndpoint
+    {
+        return $this->meetingNotesEndpoint;
     }
 
     /**

--- a/src/Endpoint/BlocksEndpoint.php
+++ b/src/Endpoint/BlocksEndpoint.php
@@ -13,6 +13,8 @@ use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
 use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
 use Brd6\NotionSdkPhp\RequestParameters;
 use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryRequest;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryResults;
 use Http\Client\Exception;
 
 class BlocksEndpoint extends AbstractEndpoint
@@ -74,6 +76,29 @@ class BlocksEndpoint extends AbstractEndpoint
         $rawData = $this->getClient()->request($requestParameters);
 
         return AbstractBlock::fromRawData($rawData);
+    }
+
+    /**
+     * Queries AI meeting notes across the workspace. Requires Notion-Version 2026-03-11.
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     * @throws UnsupportedUserTypeException
+     */
+    public function queryMeetingNotes(?MeetingNotesQueryRequest $queryRequest = null): MeetingNotesQueryResults
+    {
+        $requestParameters = (new RequestParameters())
+            ->setPath('blocks/meeting_notes/query')
+            ->setMethod('POST')
+            ->setBody($queryRequest ? $queryRequest->toArray() : []);
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        return MeetingNotesQueryResults::fromRawData($rawData);
     }
 
     public function children(): BlocksChildrenEndpoint

--- a/src/Endpoint/BlocksMeetingNotesEndpoint.php
+++ b/src/Endpoint/BlocksMeetingNotesEndpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Exception\ApiResponseException;
+use Brd6\NotionSdkPhp\Exception\HttpResponseException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceTypeException;
+use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
+use Brd6\NotionSdkPhp\RequestParameters;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryRequest;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryResults;
+use Http\Client\Exception;
+
+class BlocksMeetingNotesEndpoint extends AbstractEndpoint
+{
+    /**
+     * Queries AI meeting notes across the workspace. Requires Notion-Version 2026-03-11.
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     * @throws UnsupportedUserTypeException
+     */
+    public function query(?MeetingNotesQueryRequest $queryRequest = null): MeetingNotesQueryResults
+    {
+        $requestParameters = (new RequestParameters())
+            ->setPath('blocks/meeting_notes/query')
+            ->setMethod('POST')
+            ->setBody($queryRequest ? $queryRequest->toArray() : []);
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        return MeetingNotesQueryResults::fromRawData($rawData);
+    }
+}

--- a/src/Resource/Block/MeetingNotesQueryRequest.php
+++ b/src/Resource/Block/MeetingNotesQueryRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Resource\AbstractJsonSerializable;
+
+class MeetingNotesQueryRequest extends AbstractJsonSerializable
+{
+    protected array $filter = [];
+    protected array $sort = [];
+    protected ?int $limit = null;
+
+    public function getFilter(): array
+    {
+        return $this->filter;
+    }
+
+    public function setFilter(array $filter): self
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    public function getSort(): array
+    {
+        return $this->sort;
+    }
+
+    public function setSort(array $sort): self
+    {
+        $this->sort = $sort;
+
+        return $this;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @param int|null $limit between 1 and 50; the endpoint has no cursor pagination
+     */
+    public function setLimit(?int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+}

--- a/src/Resource/Block/MeetingNotesQueryResults.php
+++ b/src/Resource/Block/MeetingNotesQueryResults.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Block;
+
+use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\InvalidResourceTypeException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedUserTypeException;
+
+use function array_map;
+
+class MeetingNotesQueryResults
+{
+    /**
+     * @var array|AbstractBlock[]
+     */
+    protected array $results = [];
+    protected bool $hasMore = false;
+
+    /**
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws UnsupportedUserTypeException
+     */
+    public static function fromRawData(array $rawData): self
+    {
+        $queryResults = new self();
+
+        $queryResults->results = isset($rawData['results']) ? array_map(
+            fn (array $resultRawData) => AbstractBlock::fromRawData($resultRawData),
+            (array) $rawData['results'],
+        ) : [];
+        $queryResults->hasMore = (bool) ($rawData['has_more'] ?? false);
+
+        return $queryResults;
+    }
+
+    /**
+     * @return array|AbstractBlock[]
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function setResults(array $results): self
+    {
+        $this->results = $results;
+
+        return $this;
+    }
+
+    public function isHasMore(): bool
+    {
+        return $this->hasMore;
+    }
+
+    public function setHasMore(bool $hasMore): self
+    {
+        $this->hasMore = $hasMore;
+
+        return $this;
+    }
+}

--- a/tests/Endpoint/BlocksEndpointTest.php
+++ b/tests/Endpoint/BlocksEndpointTest.php
@@ -10,12 +10,16 @@ use Brd6\NotionSdkPhp\Endpoint\BlocksEndpoint;
 use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
 use Brd6\NotionSdkPhp\Resource\Block\ChildPageBlock;
 use Brd6\NotionSdkPhp\Resource\Block\Heading3Block;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesBlock;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryRequest;
+use Brd6\NotionSdkPhp\Resource\Block\MeetingNotesQueryResults;
 use Brd6\NotionSdkPhp\Resource\Block\ParagraphBlock;
 use Brd6\NotionSdkPhp\Resource\Block\TableRowBlock;
 use Brd6\NotionSdkPhp\Resource\Pagination\BlockResults;
 use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
 use Brd6\NotionSdkPhp\Resource\Property\ChildPageProperty;
 use Brd6\NotionSdkPhp\Resource\Property\HeadingProperty;
+use Brd6\NotionSdkPhp\Resource\Property\MeetingNotesProperty;
 use Brd6\NotionSdkPhp\Resource\Property\ParagraphProperty;
 use Brd6\NotionSdkPhp\Resource\RichText\Text;
 use Brd6\NotionSdkPhp\Resource\UserInterface;
@@ -513,5 +517,70 @@ class BlocksEndpointTest extends TestCase
             },
         )));
         $defaultClient->blocks()->children()->append('parent-block-id', [$buildBlock()]);
+    }
+
+    public function testQueryMeetingNotes(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString('blocks/meeting_notes/query', $url);
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals('title', $body['filter']['property']);
+            $this->assertEquals(
+                [['property' => 'last_edited_time', 'direction' => 'descending']],
+                $body['sort'],
+            );
+            $this->assertEquals(10, $body['limit']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_blocks_meeting_notes_query_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $queryRequest = (new MeetingNotesQueryRequest())
+            ->setFilter([
+                'property' => 'title',
+                'filter' => [
+                    'operator' => 'string_contains',
+                    'value' => ['type' => 'exact', 'value' => 'Sync'],
+                ],
+            ])
+            ->setSort([['property' => 'last_edited_time', 'direction' => 'descending']])
+            ->setLimit(10);
+
+        $results = $client->blocks()->queryMeetingNotes($queryRequest);
+
+        $this->assertInstanceOf(MeetingNotesQueryResults::class, $results);
+        $this->assertFalse($results->isHasMore());
+        $this->assertCount(1, $results->getResults());
+
+        $block = $results->getResults()[0];
+        $this->assertInstanceOf(MeetingNotesBlock::class, $block);
+        $this->assertEquals('Q3 Sync', $block->getMeetingNotes()->getTitle()[0]->getPlainText());
+        $this->assertEquals(MeetingNotesProperty::STATUS_NOTES_READY, $block->getMeetingNotes()->getStatus());
+    }
+
+    public function testQueryMeetingNotesWithoutRequest(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('', $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_blocks_meeting_notes_query_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $results = $client->blocks()->queryMeetingNotes();
+
+        $this->assertCount(1, $results->getResults());
     }
 }

--- a/tests/Endpoint/BlocksEndpointTest.php
+++ b/tests/Endpoint/BlocksEndpointTest.php
@@ -554,7 +554,7 @@ class BlocksEndpointTest extends TestCase
             ->setSort([['property' => 'last_edited_time', 'direction' => 'descending']])
             ->setLimit(10);
 
-        $results = $client->blocks()->queryMeetingNotes($queryRequest);
+        $results = $client->blocks()->meetingNotes()->query($queryRequest);
 
         $this->assertInstanceOf(MeetingNotesQueryResults::class, $results);
         $this->assertFalse($results->isHasMore());
@@ -579,7 +579,7 @@ class BlocksEndpointTest extends TestCase
 
         $client = new Client((new ClientOptions())->setHttpClient($httpClient));
 
-        $results = $client->blocks()->queryMeetingNotes();
+        $results = $client->blocks()->meetingNotes()->query();
 
         $this->assertCount(1, $results->getResults());
     }

--- a/tests/Fixtures/client_blocks_meeting_notes_query_200.json
+++ b/tests/Fixtures/client_blocks_meeting_notes_query_200.json
@@ -1,0 +1,60 @@
+{
+    "results": [
+        {
+            "object": "block",
+            "id": "8c1f3a52-9d47-4b8e-a316-72e05c4d9b83",
+            "created_time": "2026-07-14T14:00:00.000Z",
+            "last_edited_time": "2026-07-14T14:30:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+            },
+            "has_children": true,
+            "in_trash": false,
+            "type": "meeting_notes",
+            "meeting_notes": {
+                "title": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "Q3 Sync",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "Q3 Sync",
+                        "href": null
+                    }
+                ],
+                "status": "notes_ready",
+                "children": {
+                    "summary_block_id": "0d940186-ab70-4351-bb34-2d16f0635d50",
+                    "notes_block_id": "1e940186-ab70-4351-bb34-2d16f0635d51",
+                    "transcript_block_id": "2f940186-ab70-4351-bb34-2d16f0635d52"
+                },
+                "calendar_event": {
+                    "start_time": "2026-07-14T14:00:00Z",
+                    "end_time": "2026-07-14T14:30:00Z",
+                    "attendees": [
+                        "6794760a-1f15-45cd-9c65-0dfe42f5135a"
+                    ]
+                },
+                "recording": {
+                    "start_time": "2026-07-14T14:00:00Z",
+                    "end_time": "2026-07-14T14:30:00Z"
+                }
+            }
+        }
+    ],
+    "has_more": false
+}


### PR DESCRIPTION
## Description

Adds `blocks()->meetingNotes()->query(?MeetingNotesQueryRequest $request = null)` — a composed sub-endpoint mirroring `blocks()->children()` and the reference JS SDK's `blocks.meetingNotes.query` — against `POST /v1/blocks/meeting_notes/query` (Notion API `2026-03-11`), which searches AI meeting notes across the workspace:

- `MeetingNotesQueryRequest` carries the documented `filter` (title/attendees/created/edited filters, `and`/`or` combinators), `sort` (up to 100 sort objects), and `limit` (1–50) — filters and sorts are pass-through arrays, matching the `SearchRequest`/`DatabaseRequest` convention.
- The response is not the standard pagination envelope: it carries `results` and `has_more` only, with a `limit` instead of cursors, so it hydrates into a dedicated `MeetingNotesQueryResults` of `MeetingNotesBlock` items rather than `AbstractPaginationResults`.

## Motivation and context

The May 2026 API changelog added workspace-wide meeting-notes querying; combined with the meeting-notes block support this lets integrations find and read AI meeting notes programmatically.

## How has this been tested?

- New tests asserting the request path, filter/sort/limit body, the empty-body no-request call, and hydration of results into `MeetingNotesBlock` with title, status, and references.
- Verified against the live Notion API: the request reaches the endpoint and is parsed — this workspace's plan has AI meeting notes disabled, so the API returns its documented plan-gating error, which the SDK surfaces as a normal `ApiResponseException`.
- Full suite green (196 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
