### PR TITLE
feat(custom-emojis): support listing custom emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `$notion->customEmojis()->list()` (Notion API `2026-03-11`) to list the workspace's custom emojis, with pagination and an exact-name filter for id resolution.
 - Add `blocks()->meetingNotes()->query()` (Notion API `2026-03-11`) to search AI meeting notes across the workspace by title, attendees, dates, and editors, with sorting and a result limit — the endpoint has no cursor pagination.
 - Add comment editing (Notion API `2026-03-11`): `comments()->update()` and `updateFromMarkdown()` rewrite a comment's content, `delete()` removes it, and `createFromMarkdown()` writes a new comment as inline markdown. A connection can only edit comments it created.
 - Expose `block_type` on `UnsupportedBlock`, identifying the underlying block type (for example `form` or `button`) the API cannot represent.

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,6 +8,7 @@ use Brd6\NotionSdkPhp\Constant\NotionErrorCodeConstant;
 use Brd6\NotionSdkPhp\Endpoint\AsyncTasksEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\BlocksEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\CommentsEndpoint;
+use Brd6\NotionSdkPhp\Endpoint\CustomEmojisEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\DataSourcesEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\DatabasesEndpoint;
 use Brd6\NotionSdkPhp\Endpoint\FileUploadsEndpoint;
@@ -53,6 +54,7 @@ class Client
     private UsersEndpoint $usersEndpoint;
     private PagesEndpoint $pagesEndpoint;
     private DatabasesEndpoint $databasesEndpoint;
+    private CustomEmojisEndpoint $customEmojisEndpoint;
     private DataSourcesEndpoint $dataSourcesEndpoint;
     private FileUploadsEndpoint $fileUploadsEndpoint;
     private SearchEndpoint $searchEndpoint;
@@ -68,6 +70,7 @@ class Client
         $this->usersEndpoint = new UsersEndpoint($this);
         $this->pagesEndpoint = new PagesEndpoint($this);
         $this->databasesEndpoint = new DatabasesEndpoint($this);
+        $this->customEmojisEndpoint = new CustomEmojisEndpoint($this);
         $this->dataSourcesEndpoint = new DataSourcesEndpoint($this);
         $this->fileUploadsEndpoint = new FileUploadsEndpoint($this);
         $this->searchEndpoint = new SearchEndpoint($this);
@@ -211,6 +214,11 @@ class Client
     public function databases(): DatabasesEndpoint
     {
         return $this->databasesEndpoint;
+    }
+
+    public function customEmojis(): CustomEmojisEndpoint
+    {
+        return $this->customEmojisEndpoint;
     }
 
     public function dataSources(): DataSourcesEndpoint

--- a/src/Endpoint/CustomEmojisEndpoint.php
+++ b/src/Endpoint/CustomEmojisEndpoint.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Exception\ApiResponseException;
+use Brd6\NotionSdkPhp\Exception\HttpResponseException;
+use Brd6\NotionSdkPhp\Exception\InvalidPaginationResponseException;
+use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedPaginationResponseTypeException;
+use Brd6\NotionSdkPhp\RequestParameters;
+use Brd6\NotionSdkPhp\Resource\Pagination\AbstractPaginationResults;
+use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
+use Http\Client\Exception;
+
+use function array_merge;
+
+class CustomEmojisEndpoint extends AbstractEndpoint
+{
+    /**
+     * Requires Notion-Version 2026-03-11.
+     *
+     * @param string|null $name filters custom emojis by exact name match
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidPaginationResponseException
+     * @throws RequestTimeoutException
+     * @throws UnsupportedPaginationResponseTypeException
+     */
+    public function list(?string $name = null, ?PaginationRequest $paginationRequest = null): AbstractPaginationResults
+    {
+        $paginationRequest = $paginationRequest ?? new PaginationRequest();
+
+        $query = array_merge(
+            $paginationRequest->toArray(),
+            $name !== null ? ['name' => $name] : [],
+        );
+
+        $requestParameters = (new RequestParameters())
+            ->setPath('custom_emojis')
+            ->setQuery($query)
+            ->setMethod('GET');
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        return AbstractPaginationResults::fromRawData($rawData);
+    }
+}

--- a/src/Resource/Pagination/CustomEmojiResults.php
+++ b/src/Resource/Pagination/CustomEmojiResults.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Pagination;
+
+use Brd6\NotionSdkPhp\Resource\Property\CustomEmojiProperty;
+
+use function array_map;
+
+class CustomEmojiResults extends AbstractPaginationResults
+{
+    protected function initialize(): void
+    {
+        $this->results = isset($this->getRawData()['results']) ? array_map(
+            fn (array $resultRawData) => CustomEmojiProperty::fromRawData($resultRawData),
+            (array) $this->getRawData()['results'],
+        ) : [];
+    }
+
+    /**
+     * @return CustomEmojiProperty[]|array
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+}

--- a/tests/Endpoint/CustomEmojisEndpointTest.php
+++ b/tests/Endpoint/CustomEmojisEndpointTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Endpoint;
+
+use Brd6\NotionSdkPhp\Client;
+use Brd6\NotionSdkPhp\ClientOptions;
+use Brd6\NotionSdkPhp\Endpoint\CustomEmojisEndpoint;
+use Brd6\NotionSdkPhp\Resource\Pagination\CustomEmojiResults;
+use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
+use Brd6\NotionSdkPhp\Resource\Property\CustomEmojiProperty;
+use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockHttpClient;
+use Brd6\Test\NotionSdkPhp\Mock\HttpClient\MockResponseFactory;
+use Brd6\Test\NotionSdkPhp\TestCase;
+
+use function count;
+use function file_get_contents;
+
+class CustomEmojisEndpointTest extends TestCase
+{
+    public function testInstance(): void
+    {
+        $client = new Client();
+        $customEmojis = new CustomEmojisEndpoint($client);
+
+        $this->assertInstanceOf(CustomEmojisEndpoint::class, $client->customEmojis());
+        $this->assertInstanceOf(CustomEmojisEndpoint::class, $customEmojis);
+    }
+
+    public function testListCustomEmojis(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('GET', $method);
+            $this->assertStringContainsString('custom_emojis', $url);
+            $this->assertArrayNotHasKey('name', $options['query']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_custom_emojis_list_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $results = $client->customEmojis()->list();
+
+        $this->assertInstanceOf(CustomEmojiResults::class, $results);
+        $this->assertEquals(2, count($results->getResults()));
+        $this->assertFalse($results->isHasMore());
+
+        $emoji = $results->getResults()[0];
+        $this->assertInstanceOf(CustomEmojiProperty::class, $emoji);
+        $this->assertEquals('party_parrot', $emoji->getName());
+        $this->assertNotEmpty($emoji->getUrl());
+        $this->assertNotEmpty($emoji->getId());
+    }
+
+    public function testListCustomEmojisWithNameAndPagination(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('shipit', $options['query']['name']);
+            $this->assertEquals(10, (int) $options['query']['page_size']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_custom_emojis_list_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $client->customEmojis()->list('shipit', (new PaginationRequest())->setPageSize(10));
+    }
+}

--- a/tests/Fixtures/client_custom_emojis_list_200.json
+++ b/tests/Fixtures/client_custom_emojis_list_200.json
@@ -1,0 +1,19 @@
+{
+    "object": "list",
+    "results": [
+        {
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "name": "party_parrot",
+            "url": "https://s3-us-west-2.amazonaws.com/public.notion-static.com/custom_emojis/party_parrot.gif"
+        },
+        {
+            "id": "660f9511-f3ac-52e5-b827-557766551111",
+            "name": "shipit",
+            "url": "https://s3-us-west-2.amazonaws.com/public.notion-static.com/custom_emojis/shipit.png"
+        }
+    ],
+    "next_cursor": null,
+    "has_more": false,
+    "type": "custom_emoji",
+    "custom_emoji": {}
+}


### PR DESCRIPTION
## Description

Adds `$notion->customEmojis()->list(?string $name = null, ?PaginationRequest $paginationRequest = null)` against `GET /v1/custom_emojis` (Notion API `2026-03-11`):

- Standard list envelope (`type: "custom_emoji"`) hydrated through the pagination convention into a new `CustomEmojiResults`.
- Result items reuse the existing `CustomEmojiProperty` — their `{id, name, url}` shape matches it exactly, so no new item model was needed.
- The optional `$name` parameter is the API's exact-match filter, useful for resolving an emoji name to its id.
- The `customEmojis()` accessor mirrors the reference JavaScript SDK's top-level `customEmojis` namespace.

## Motivation and context

The March 2026 API changelog added custom emoji listing; the SDK could already hydrate custom emojis appearing in mentions and icons but had no way to enumerate them or resolve a name to an id.

## How has this been tested?

- New tests asserting the request path, the name/pagination query parameters, and hydration of results into `CustomEmojiProperty` items.
- Verified live against the Notion API: the list call returns a valid envelope (this workspace has no custom emojis, so an empty result set — hydrated cleanly), and the name filter is accepted.
- Full suite green (199 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
