### PR TITLE
feat(resource): support locking pages and databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `isLocked()`/`setLocked()` on `Page` and `Database`: pages and databases can be locked or unlocked through `update()`, and hydration reflects the `is_locked` state. Updates that never call `setLocked()` send byte-identical payloads to before.
 - Add `$notion->customEmojis()->list()` (Notion API `2026-03-11`) to list the workspace's custom emojis, with pagination and an exact-name filter for id resolution.
 - Add `blocks()->meetingNotes()->query()` (Notion API `2026-03-11`) to search AI meeting notes across the workspace by title, attendees, dates, and editors, with sorting and a result limit — the endpoint has no cursor pagination.
 - Add comment editing (Notion API `2026-03-11`): `comments()->update()` and `updateFromMarkdown()` rewrite a comment's content, `delete()` removes it, and `createFromMarkdown()` writes a new comment as inline markdown. A connection can only edit comments it created.

--- a/src/Resource/Database.php
+++ b/src/Resource/Database.php
@@ -19,12 +19,13 @@ use Brd6\NotionSdkPhp\Resource\RichText\AbstractRichText;
 use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
 use DateTimeImmutable;
 
+use function array_key_exists;
 use function array_map;
 
 class Database extends AbstractResource
 {
     public const RESOURCE_TYPE = 'database';
-    private const UPDATE_ACCEPTED_KEYS = ['title', 'properties', 'icon', 'cover'];
+    private const UPDATE_ACCEPTED_KEYS = ['title', 'properties', 'icon', 'cover', 'is_locked'];
 
     protected ?DateTimeImmutable $createdTime = null;
     protected ?UserInterface $createdBy = null;
@@ -52,6 +53,7 @@ class Database extends AbstractResource
     protected ?AbstractParentProperty $parent = null;
     protected string $url = '';
     protected bool $archived = false;
+    protected ?bool $isLocked = null;
 
     public function __construct()
     {
@@ -62,7 +64,13 @@ class Database extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        return $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+        $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+
+        if ($this->isLocked === null) {
+            unset($data['is_locked']);
+        }
+
+        return $data;
     }
 
     /**
@@ -85,6 +93,9 @@ class Database extends AbstractResource
             null;
         $this->lastEditedBy = AbstractUser::fromRawData((array) ($this->getRawData()['last_edited_by'] ?? []));
         $this->archived = (bool) ($this->getRawData()['archived'] ?? $this->getRawData()['in_trash'] ?? false);
+        $this->isLocked = array_key_exists('is_locked', $this->getRawData())
+            ? (bool) $this->getRawData()['is_locked']
+            : null;
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;
@@ -172,6 +183,18 @@ class Database extends AbstractResource
     public function isInTrash(): bool
     {
         return $this->isArchived();
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->isLocked ?? false;
+    }
+
+    public function setLocked(bool $isLocked): self
+    {
+        $this->isLocked = $isLocked;
+
+        return $this;
     }
 
     public function setInTrash(bool $inTrash): self

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -23,13 +23,14 @@ class Page extends AbstractResource
 {
     public const RESOURCE_TYPE = 'page';
     private const CREATE_ACCEPTED_KEYS = ['object', 'properties', 'parent', 'icon', 'cover'];
-    private const UPDATE_ACCEPTED_KEYS = ['properties', 'archived', 'icon', 'cover'];
+    private const UPDATE_ACCEPTED_KEYS = ['properties', 'archived', 'icon', 'cover', 'is_locked'];
 
     protected ?DateTimeImmutable $createdTime = null;
     protected ?UserInterface $createdBy = null;
     protected ?DateTimeImmutable $lastEditedTime = null;
     protected ?UserInterface $lastEditedBy = null;
     protected ?bool $archived = null;
+    protected ?bool $isLocked = null;
     protected ?AbstractFile $icon = null;
     protected ?AbstractFile $cover = null;
 
@@ -67,6 +68,10 @@ class Page extends AbstractResource
             unset($data['archived']);
         }
 
+        if ($this->isLocked === null) {
+            unset($data['is_locked']);
+        }
+
         return $data;
     }
 
@@ -90,6 +95,9 @@ class Page extends AbstractResource
             : (array_key_exists('in_trash', $this->getRawData())
                 ? (bool) $this->getRawData()['in_trash']
                 : null);
+        $this->isLocked = array_key_exists('is_locked', $this->getRawData())
+            ? (bool) $this->getRawData()['is_locked']
+            : null;
         $this->icon = isset($this->getRawData()['icon']) ?
             AbstractFile::fromRawData((array) $this->getRawData()['icon']) :
             null;
@@ -169,6 +177,18 @@ class Page extends AbstractResource
     public function isInTrash(): bool
     {
         return $this->isArchived();
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->isLocked ?? false;
+    }
+
+    public function setLocked(bool $isLocked): self
+    {
+        $this->isLocked = $isLocked;
+
+        return $this;
     }
 
     public function setInTrash(bool $inTrash): self

--- a/tests/Resource/DatabaseTest.php
+++ b/tests/Resource/DatabaseTest.php
@@ -27,6 +27,27 @@ class DatabaseTest extends TestCase
         Database::fromRawData([]);
     }
 
+    public function testDatabaseIsLockedRoundTrip(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_databases_retrieve_database_200.json'),
+            true,
+        );
+        $rawData['is_locked'] = true;
+
+        /** @var Database $database */
+        $database = Database::fromRawData($rawData);
+
+        $this->assertTrue($database->isLocked());
+
+        $unset = new Database();
+        $this->assertArrayNotHasKey('is_locked', $unset->toArrayForUpdate());
+
+        $locked = new Database();
+        $locked->setLocked(false);
+        $this->assertFalse($locked->toArrayForUpdate()['is_locked']);
+    }
+
     public function testDatabaseHydratesInTrashPayloadWithoutArchivedKey(): void
     {
         $rawData = (array) json_decode(

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -182,6 +182,35 @@ class PageTest extends TestCase
         $this->assertTrue($page->isInTrash());
     }
 
+    public function testPageHydratesIsLocked(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+            true,
+        );
+        $rawData['is_locked'] = true;
+
+        /** @var Page $page */
+        $page = Page::fromRawData($rawData);
+
+        $this->assertTrue($page->isLocked());
+    }
+
+    public function testPageToArrayForUpdateOmitsIsLockedWhenUnset(): void
+    {
+        $page = $this->createPageForUpdateSerialization();
+
+        $this->assertArrayNotHasKey('is_locked', $page->toArrayForUpdate());
+    }
+
+    public function testPageToArrayForUpdateIncludesIsLockedWhenSet(): void
+    {
+        $page = $this->createPageForUpdateSerialization();
+        $page->setLocked(true);
+
+        $this->assertTrue($page->toArrayForUpdate()['is_locked']);
+    }
+
     public function testPageIsArchivedReturnsFalseWhenUnset(): void
     {
         $page = new Page();


### PR DESCRIPTION
## Description

Adds lock support for pages and databases:

- `Page` and `Database` gain `isLocked()`/`setLocked()`; the `is_locked` field hydrates from responses and serializes in `toArrayForUpdate()` only when explicitly set, following the tri-state pattern the page `archived` handling established (#67) — updates that never touch it send byte-identical payloads to before, pinned by tests.

```php
$page = new Page();
$page->setId($pageId);
$page->setLocked(true);
$notion->pages()->update($page);
```

## Motivation and context

The API's `is_locked` parameter (September 2025) lets integrations prevent accidental edits to managed pages and databases; the SDK hydrated payloads containing the field tolerantly but offered no way to read or set it.

## How has this been tested?

- New tests: hydration of `is_locked` on both resources, update serialization when set (`true` and explicit `false`), and omission when unset.
- Verified live against the Notion API: locked and unlocked a real page and a real database through `update()`, with each response hydrating the new state correctly.
- Full suite green (203 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
