### PR TITLE
feat(pagination): expose request status on paginated results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Expose `request_status` on paginated results, so consumers can detect incomplete result sets (for example when a query hits the API's pagination depth limit) via `getRequestStatus()`.
 - Add `isLocked()`/`setLocked()` on `Page` and `Database`: pages and databases can be locked or unlocked through `update()`, and hydration reflects the `is_locked` state. Updates that never call `setLocked()` send byte-identical payloads to before.
 - Add `$notion->customEmojis()->list()` (Notion API `2026-03-11`) to list the workspace's custom emojis, with pagination and an exact-name filter for id resolution.
 - Add `blocks()->meetingNotes()->query()` (Notion API `2026-03-11`) to search AI meeting notes across the workspace by title, attendees, dates, and editors, with sorting and a result limit — the endpoint has no cursor pagination.

--- a/src/Resource/Pagination/AbstractPaginationResults.php
+++ b/src/Resource/Pagination/AbstractPaginationResults.php
@@ -18,6 +18,7 @@ abstract class AbstractPaginationResults extends AbstractJsonSerializable
     protected array $results = [];
     protected string $object = '';
     protected string $type = '';
+    protected array $requestStatus = [];
     private array $rawData = [];
 
     /**
@@ -122,6 +123,18 @@ abstract class AbstractPaginationResults extends AbstractJsonSerializable
         return $this;
     }
 
+    public function getRequestStatus(): array
+    {
+        return $this->requestStatus;
+    }
+
+    public function setRequestStatus(array $requestStatus): self
+    {
+        $this->requestStatus = $requestStatus;
+
+        return $this;
+    }
+
     public function getRawData(): array
     {
         return $this->rawData;
@@ -137,6 +150,7 @@ abstract class AbstractPaginationResults extends AbstractJsonSerializable
             ((string) $this->getRawData()['next_cursor']) :
             null;
         $this->hasMore = (bool) $this->getRawData()['next_cursor'];
+        $this->requestStatus = (array) ($this->getRawData()['request_status'] ?? []);
 
         return $this;
     }

--- a/tests/Resource/Pagination/CommentResultsTest.php
+++ b/tests/Resource/Pagination/CommentResultsTest.php
@@ -38,4 +38,33 @@ class CommentResultsTest extends TestCase
         $this->assertEquals('8b3cfeed-c0da-451e-8f18-f7086c321980', $results[1]->getId());
         $this->assertEquals('This is another comment', $results[1]->getRichText()[0]->getPlainText());
     }
+
+    public function testRequestStatus(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/comments_list_200.json'),
+            true,
+        );
+        $rawData['request_status'] = [
+            'type' => 'incomplete',
+            'incomplete_reason' => 'query_result_limit_reached',
+        ];
+
+        $commentResults = CommentResults::fromRawData($rawData);
+
+        $this->assertEquals('incomplete', $commentResults->getRequestStatus()['type']);
+        $this->assertEquals('query_result_limit_reached', $commentResults->getRequestStatus()['incomplete_reason']);
+    }
+
+    public function testRequestStatusAbsent(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/comments_list_200.json'),
+            true,
+        );
+
+        $commentResults = CommentResults::fromRawData($rawData);
+
+        $this->assertEquals([], $commentResults->getRequestStatus());
+    }
 }


### PR DESCRIPTION
## Description

`AbstractPaginationResults` now hydrates the `request_status` field the API attaches to list responses (`{type: "complete" | "incomplete", incomplete_reason}`), exposed as `getRequestStatus()` on every paginated result. Responses without the field return an empty array.

## Motivation and context

The April 2026 API changelog introduced a pagination depth limit (10,000 results) together with `request_status`, so consumers can tell a genuinely complete result set from one the API truncated. The SDK dropped the field during hydration, leaving no way to detect truncation.

## How has this been tested?

- New tests covering both shapes: an incomplete status with its reason, and the field absent.
- Live sanity check: a real list response without the field hydrates to an empty status. The incomplete state itself cannot be forced on a small workspace, so it is covered by the doc-shaped fixture mutation.
- Full suite green (205 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
