### PR TITLE
feat(pages): support moving pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `pages()->move()` to move a page under a new page or data source parent.
+
 ## 1.11.0 - 2026-07-14
 
 ### Added

--- a/src/Endpoint/PagesEndpoint.php
+++ b/src/Endpoint/PagesEndpoint.php
@@ -15,6 +15,7 @@ use Brd6\NotionSdkPhp\Resource\AsyncTask;
 use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
 use Brd6\NotionSdkPhp\Resource\Page;
 use Brd6\NotionSdkPhp\Resource\Page\PageMarkdownRequest;
+use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
 use Brd6\NotionSdkPhp\Resource\PageMarkdown;
 use Http\Client\Exception;
 
@@ -109,6 +110,31 @@ class PagesEndpoint extends AbstractEndpoint
         $pageUpdated = Page::fromRawData($rawData);
 
         return $pageUpdated;
+    }
+
+    /**
+     * Moves a page under a new page or data source parent.
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws InvalidResourceException
+     * @throws InvalidResourceTypeException
+     * @throws RequestTimeoutException
+     */
+    public function move(string $pageId, AbstractParentProperty $parent): Page
+    {
+        $requestParameters = (new RequestParameters())
+            ->setPath("pages/$pageId/move")
+            ->setMethod('POST')
+            ->setBody(['parent' => $parent->toArray()]);
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        /** @var Page $pageMoved */
+        $pageMoved = Page::fromRawData($rawData);
+
+        return $pageMoved;
     }
 
     /**

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -769,6 +769,62 @@ class PagesEndpointTest extends TestCase
         $currentClient->pages()->update($buildPage());
     }
 
+    public function testMovePage(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertEquals('POST', $method);
+            $this->assertStringContainsString(
+                'pages/b55c9c91-384d-452b-81db-d1ef79372b75/move',
+                $url,
+            );
+
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals(
+                ['parent' => ['type' => 'page_id', 'page_id' => '59833787-2cf9-4fdf-8782-e53db20768a5']],
+                $body,
+            );
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = $client->pages()->move(
+            'b55c9c91-384d-452b-81db-d1ef79372b75',
+            (new PageIdParent())->setPageId('59833787-2cf9-4fdf-8782-e53db20768a5'),
+        );
+
+        $this->assertInstanceOf(Page::class, $page);
+    }
+
+    public function testMovePageToDataSource(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals('data_source_id', $body['parent']['type']);
+            $this->assertEquals('1a44be12-0953-4631-b498-9e5817518db8', $body['parent']['data_source_id']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $client->pages()->move(
+            'b55c9c91-384d-452b-81db-d1ef79372b75',
+            (new DataSourceIdParent())->setDataSourceId('1a44be12-0953-4631-b498-9e5817518db8'),
+        );
+    }
+
     private function buildMarkdownPage(): Page
     {
         $page = new Page();


### PR DESCRIPTION
## Description

Adds `pages()->move(string $pageId, AbstractParentProperty $parent): Page` against `POST /v1/pages/{page_id}/move`, mirroring the reference JavaScript SDK's `pages.move`. The new parent is expressed with the existing typed parent classes — `PageIdParent` or `DataSourceIdParent` — so the two documented target kinds need no new models.

```php
$notion->pages()->move($pageId, (new PageIdParent())->setPageId($newParentId));
```

## Motivation and context

The January 2026 API changelog added page moving; without it, relocating a page means recreating it and losing its id, comments, and history.

## How has this been tested?

- New tests asserting the request path and both documented parent body shapes (`page_id` and `data_source_id`).
- Verified live against the Notion API: created two pages, moved one under the other, and confirmed the response hydrates the new parent id. Test pages trashed afterwards.
- Full suite green (207 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
