### PR TITLE
feat(pages): support positioning created pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add an optional `PagePosition` to `pages()->create()`, `createFromMarkdown()`, and `createFromMarkdownAsync()` to place the new page at the start or end of its parent or after a specific block (`PagePosition::pageStart()`, `::pageEnd()`, `::afterBlock()`).
 - Add `pages()->move()` to move a page under a new page or data source parent.
 
 ## 1.11.0 - 2026-07-14

--- a/src/Endpoint/PagesEndpoint.php
+++ b/src/Endpoint/PagesEndpoint.php
@@ -15,6 +15,7 @@ use Brd6\NotionSdkPhp\Resource\AsyncTask;
 use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
 use Brd6\NotionSdkPhp\Resource\Page;
 use Brd6\NotionSdkPhp\Resource\Page\PageMarkdownRequest;
+use Brd6\NotionSdkPhp\Resource\Page\PagePosition;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
 use Brd6\NotionSdkPhp\Resource\PageMarkdown;
 use Http\Client\Exception;
@@ -68,11 +69,15 @@ class PagesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
-    public function create(Page $page, array $children = []): Page
+    public function create(Page $page, array $children = [], ?PagePosition $position = null): Page
     {
         $childrenData = array_map(fn (AbstractBlock $block) => $block->toArrayForCreate(), $children);
 
         $data = array_merge($this->normalizeTrashKey($page->toArrayForCreate()), ['children' => $childrenData]);
+
+        if ($position !== null) {
+            $data['position'] = $position->toArray();
+        }
 
         $requestParameters = (new RequestParameters())
             ->setPath('pages')
@@ -148,10 +153,10 @@ class PagesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
-    public function createFromMarkdown(Page $page, string $markdown): Page
+    public function createFromMarkdown(Page $page, string $markdown, ?PagePosition $position = null): Page
     {
         $rawData = $this->getClient()->request(
-            $this->buildCreateFromMarkdownParameters($page, $markdown, false),
+            $this->buildCreateFromMarkdownParameters($page, $markdown, false, $position),
         );
 
         /** @var Page $pageCreated */
@@ -171,10 +176,10 @@ class PagesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
-    public function createFromMarkdownAsync(Page $page, string $markdown): AsyncTask
+    public function createFromMarkdownAsync(Page $page, string $markdown, ?PagePosition $position = null): AsyncTask
     {
         $rawData = $this->getClient()->request(
-            $this->buildCreateFromMarkdownParameters($page, $markdown, true),
+            $this->buildCreateFromMarkdownParameters($page, $markdown, true, $position),
         );
 
         /** @var AsyncTask $asyncTask */
@@ -259,7 +264,8 @@ class PagesEndpoint extends AbstractEndpoint
     private function buildCreateFromMarkdownParameters(
         Page $page,
         string $markdown,
-        bool $allowAsync
+        bool $allowAsync,
+        ?PagePosition $position = null
     ): RequestParameters {
         $data = array_merge(
             $this->normalizeTrashKey($page->toArrayForCreate()),
@@ -268,6 +274,10 @@ class PagesEndpoint extends AbstractEndpoint
 
         if ($allowAsync) {
             $data['allow_async'] = true;
+        }
+
+        if ($position !== null) {
+            $data['position'] = $position->toArray();
         }
 
         return (new RequestParameters())

--- a/src/Resource/Page/PagePosition.php
+++ b/src/Resource/Page/PagePosition.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Page;
+
+class PagePosition
+{
+    public const TYPE_AFTER_BLOCK = 'after_block';
+    public const TYPE_PAGE_START = 'page_start';
+    public const TYPE_PAGE_END = 'page_end';
+
+    protected string $type;
+    protected ?string $afterBlockId;
+
+    private function __construct(string $type, ?string $afterBlockId = null)
+    {
+        $this->type = $type;
+        $this->afterBlockId = $afterBlockId;
+    }
+
+    public static function afterBlock(string $blockId): self
+    {
+        return new self(self::TYPE_AFTER_BLOCK, $blockId);
+    }
+
+    public static function pageStart(): self
+    {
+        return new self(self::TYPE_PAGE_START);
+    }
+
+    public static function pageEnd(): self
+    {
+        return new self(self::TYPE_PAGE_END);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getAfterBlockId(): ?string
+    {
+        return $this->afterBlockId;
+    }
+
+    public function toArray(): array
+    {
+        $data = ['type' => $this->type];
+
+        if ($this->afterBlockId !== null) {
+            $data['after_block'] = ['id' => $this->afterBlockId];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -19,6 +19,7 @@ use Brd6\NotionSdkPhp\Resource\File\File;
 use Brd6\NotionSdkPhp\Resource\Page;
 use Brd6\NotionSdkPhp\Resource\Page\MarkdownContentUpdate;
 use Brd6\NotionSdkPhp\Resource\Page\PageMarkdownRequest;
+use Brd6\NotionSdkPhp\Resource\Page\PagePosition;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\DataSourceIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\PageIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyItem\AbstractPropertyItem;
@@ -823,6 +824,75 @@ class PagesEndpointTest extends TestCase
             'b55c9c91-384d-452b-81db-d1ef79372b75',
             (new DataSourceIdParent())->setDataSourceId('1a44be12-0953-4631-b498-9e5817518db8'),
         );
+    }
+
+    public function testCreatePageWithPosition(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals(
+                ['type' => 'after_block', 'after_block' => ['id' => '7d50a184-5bbe-4d90-8f29-6bec57ed817b']],
+                $body['position'],
+            );
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = new Page();
+        $page->setParent((new PageIdParent())->setPageId('4a808e6e-8845-4d49-a447-fb2a4c460f6f'));
+        $page->setProperties(['title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Positioned')])]);
+
+        $client->pages()->create($page, [], PagePosition::afterBlock('7d50a184-5bbe-4d90-8f29-6bec57ed817b'));
+    }
+
+    public function testCreatePageFromMarkdownWithPosition(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals(['type' => 'page_start'], $body['position']);
+            $this->assertEquals('# Title', $body['markdown']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $client->pages()->createFromMarkdown($this->buildMarkdownPage(), '# Title', PagePosition::pageStart());
+    }
+
+    public function testCreatePageWithoutPositionOmitsKey(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayNotHasKey('position', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = new Page();
+        $page->setParent((new PageIdParent())->setPageId('4a808e6e-8845-4d49-a447-fb2a4c460f6f'));
+        $page->setProperties(['title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Plain')])]);
+
+        $client->pages()->create($page);
     }
 
     private function buildMarkdownPage(): Page


### PR DESCRIPTION
## Description

Adds an optional `PagePosition` parameter to `pages()->create()`, `createFromMarkdown()`, and `createFromMarkdownAsync()`, controlling where the new page lands inside its parent:

```php
$notion->pages()->create($page, [], PagePosition::pageStart());
$notion->pages()->createFromMarkdown($page, $markdown, PagePosition::afterBlock($blockId));
```

`PagePosition` is a small value object with one constructor per documented placement (`page_start`, `page_end`, `after_block`), serializing to the API's position schema. Creates that pass no position send byte-identical payloads to before, pinned by a test.

## Motivation and context

The January 2026 API changelog added placement control for new pages; without it every created page is appended at the end of its parent.

## How has this been tested?

- New tests asserting the `after_block` and `page_start` body shapes and the omission when no position is given.
- Verified live against the Notion API: a page created with `pageStart()` became the parent's first child, and a second created with `afterBlock()` landed directly after it — confirmed by listing the parent's children. Test pages trashed afterwards.
- Full suite green (210 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
