### PR TITLE
feat(pages): support page templates and erasing content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add page template support: an optional `PageTemplate` on `pages()->create()` and `update()` applies a data source's default template or a specific template (`PageTemplate::none()`, `::defaultTemplate()`, `::templateId()`, with an optional timezone for relative dates), and an optional `$eraseContent` flag on `update()` clears existing page content.
 - Add an optional `PagePosition` to `pages()->create()`, `createFromMarkdown()`, and `createFromMarkdownAsync()` to place the new page at the start or end of its parent or after a specific block (`PagePosition::pageStart()`, `::pageEnd()`, `::afterBlock()`).
 - Add `pages()->move()` to move a page under a new page or data source parent.
 

--- a/src/Endpoint/PagesEndpoint.php
+++ b/src/Endpoint/PagesEndpoint.php
@@ -16,6 +16,7 @@ use Brd6\NotionSdkPhp\Resource\Block\AbstractBlock;
 use Brd6\NotionSdkPhp\Resource\Page;
 use Brd6\NotionSdkPhp\Resource\Page\PageMarkdownRequest;
 use Brd6\NotionSdkPhp\Resource\Page\PagePosition;
+use Brd6\NotionSdkPhp\Resource\Page\PageTemplate;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
 use Brd6\NotionSdkPhp\Resource\PageMarkdown;
 use Http\Client\Exception;
@@ -69,14 +70,22 @@ class PagesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
-    public function create(Page $page, array $children = [], ?PagePosition $position = null): Page
-    {
+    public function create(
+        Page $page,
+        array $children = [],
+        ?PagePosition $position = null,
+        ?PageTemplate $template = null
+    ): Page {
         $childrenData = array_map(fn (AbstractBlock $block) => $block->toArrayForCreate(), $children);
 
         $data = array_merge($this->normalizeTrashKey($page->toArrayForCreate()), ['children' => $childrenData]);
 
         if ($position !== null) {
             $data['position'] = $position->toArray();
+        }
+
+        if ($template !== null) {
+            $data['template'] = $template->toArray();
         }
 
         $requestParameters = (new RequestParameters())
@@ -102,12 +111,22 @@ class PagesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
-    public function update(Page $page): Page
+    public function update(Page $page, ?PageTemplate $template = null, ?bool $eraseContent = null): Page
     {
+        $data = $this->normalizeTrashKey($page->toArrayForUpdate());
+
+        if ($template !== null) {
+            $data['template'] = $template->toArray();
+        }
+
+        if ($eraseContent !== null) {
+            $data['erase_content'] = $eraseContent;
+        }
+
         $requestParameters = (new RequestParameters())
             ->setPath("pages/{$page->getId()}")
             ->setMethod('PATCH')
-            ->setBody($this->normalizeTrashKey($page->toArrayForUpdate()));
+            ->setBody($data);
 
         $rawData = $this->getClient()->request($requestParameters);
 

--- a/src/Resource/Page/PageTemplate.php
+++ b/src/Resource/Page/PageTemplate.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\Page;
+
+class PageTemplate
+{
+    public const TYPE_NONE = 'none';
+    public const TYPE_DEFAULT = 'default';
+    public const TYPE_TEMPLATE_ID = 'template_id';
+
+    protected string $type;
+    protected ?string $templateId;
+    protected ?string $timezone;
+
+    private function __construct(string $type, ?string $templateId = null, ?string $timezone = null)
+    {
+        $this->type = $type;
+        $this->templateId = $templateId;
+        $this->timezone = $timezone;
+    }
+
+    /**
+     * Creates the page without applying any template; only valid on page creation.
+     */
+    public static function none(): self
+    {
+        return new self(self::TYPE_NONE);
+    }
+
+    /**
+     * Applies the data source's default template; the timezone resolves the template's
+     * relative dates.
+     */
+    public static function defaultTemplate(?string $timezone = null): self
+    {
+        return new self(self::TYPE_DEFAULT, null, $timezone);
+    }
+
+    public static function templateId(string $templateId, ?string $timezone = null): self
+    {
+        return new self(self::TYPE_TEMPLATE_ID, $templateId, $timezone);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getTemplateId(): ?string
+    {
+        return $this->templateId;
+    }
+
+    public function getTimezone(): ?string
+    {
+        return $this->timezone;
+    }
+
+    public function toArray(): array
+    {
+        $data = ['type' => $this->type];
+
+        if ($this->templateId !== null) {
+            $data['template_id'] = $this->templateId;
+        }
+
+        if ($this->timezone !== null) {
+            $data['timezone'] = $this->timezone;
+        }
+
+        return $data;
+    }
+}

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -20,6 +20,7 @@ use Brd6\NotionSdkPhp\Resource\Page;
 use Brd6\NotionSdkPhp\Resource\Page\MarkdownContentUpdate;
 use Brd6\NotionSdkPhp\Resource\Page\PageMarkdownRequest;
 use Brd6\NotionSdkPhp\Resource\Page\PagePosition;
+use Brd6\NotionSdkPhp\Resource\Page\PageTemplate;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\DataSourceIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\PageIdParent;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyItem\AbstractPropertyItem;
@@ -893,6 +894,87 @@ class PagesEndpointTest extends TestCase
         $page->setProperties(['title' => (new TitlePropertyValue())->setTitle([Text::fromContent('Plain')])]);
 
         $client->pages()->create($page);
+    }
+
+    public function testCreatePageWithTemplate(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals(
+                [
+                    'type' => 'template_id',
+                    'template_id' => '195de922-1179-449f-ab80-75a27c979105',
+                    'timezone' => 'Europe/Paris',
+                ],
+                $body['template'],
+            );
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = new Page();
+        $page->setParent((new PageIdParent())->setPageId('4a808e6e-8845-4d49-a447-fb2a4c460f6f'));
+
+        $client->pages()->create(
+            $page,
+            [],
+            null,
+            PageTemplate::templateId('195de922-1179-449f-ab80-75a27c979105', 'Europe/Paris'),
+        );
+    }
+
+    public function testUpdatePageWithTemplateAndEraseContent(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertEquals(['type' => 'default'], $body['template']);
+            $this->assertTrue($body['erase_content']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = new Page();
+        $page->setId('1e7e638f78864ec591ea54ec7016e146');
+
+        $client->pages()->update($page, PageTemplate::defaultTemplate(), true);
+    }
+
+    public function testUpdatePageWithoutTemplateOmitsKeys(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayNotHasKey('template', $body);
+            $this->assertArrayNotHasKey('erase_content', $body);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = new Page();
+        $page->setId('1e7e638f78864ec591ea54ec7016e146');
+        $page->setArchived(true);
+
+        $client->pages()->update($page);
     }
 
     private function buildMarkdownPage(): Page


### PR DESCRIPTION
## Description

Adds page template support and content erasure:

- `pages()->create($page, $children, $position, ?PageTemplate $template)` and `pages()->update($page, ?PageTemplate $template, ?bool $eraseContent)`.
- `PageTemplate` is a value object with one constructor per documented variant — `::none()` (creation only), `::defaultTemplate(?string $timezone)`, and `::templateId(string $id, ?string $timezone)` — the timezone resolving the template's relative dates. Invalid combinations are unrepresentable, following the `PagePosition` pattern.
- `$eraseContent` on update clears the page's existing content; combined with a template, the template content replaces it.
- Calls passing neither send byte-identical payloads to before, pinned by a test.

## Motivation and context

The January 2026 API changelog added template application and content erasure to the pages API; without them, applying a data source template or resetting a page's content requires manual block manipulation.

## How has this been tested?

- New tests asserting the `template_id` + timezone create body, the `default` template + `erase_content` update body, and key omission when unset.
- Verified live against the Notion API: a page with real content was cleared through `update($page, null, true)` (markdown read-back went from the content to an empty string), and creation with `PageTemplate::none()` was accepted. The `default`/`template_id` variants need actual data source templates, which this workspace has none of — their body shapes are covered by the unit tests.
- Full suite green (213 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
