### PR TITLE
feat(data-sources): support listing data source templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `dataSources()->listTemplates()` to list a data source's page templates (id, name, default flag), with pagination and a name filter — pairs with `PageTemplate::templateId()` for applying one.
 - Add page template support: an optional `PageTemplate` on `pages()->create()` and `update()` applies a data source's default template or a specific template (`PageTemplate::none()`, `::defaultTemplate()`, `::templateId()`, with an optional timezone for relative dates), and an optional `$eraseContent` flag on `update()` clears existing page content.
 - Add an optional `PagePosition` to `pages()->create()`, `createFromMarkdown()`, and `createFromMarkdownAsync()` to place the new page at the start or end of its parent or after a specific block (`PagePosition::pageStart()`, `::pageEnd()`, `::afterBlock()`).
 - Add `pages()->move()` to move a page under a new page or data source parent.

--- a/src/Endpoint/DataSourcesEndpoint.php
+++ b/src/Endpoint/DataSourcesEndpoint.php
@@ -106,6 +106,7 @@ class DataSourcesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
+
     /**
      * Lists the page templates available in a data source.
      *

--- a/src/Endpoint/DataSourcesEndpoint.php
+++ b/src/Endpoint/DataSourcesEndpoint.php
@@ -13,6 +13,7 @@ use Brd6\NotionSdkPhp\Exception\RequestTimeoutException;
 use Brd6\NotionSdkPhp\Exception\UnsupportedPaginationResponseTypeException;
 use Brd6\NotionSdkPhp\RequestParameters;
 use Brd6\NotionSdkPhp\Resource\DataSource;
+use Brd6\NotionSdkPhp\Resource\DataSource\DataSourceTemplateResults;
 use Brd6\NotionSdkPhp\Resource\Database\DatabaseRequest;
 use Brd6\NotionSdkPhp\Resource\Pagination\AbstractPaginationResults;
 use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
@@ -105,6 +106,38 @@ class DataSourcesEndpoint extends AbstractEndpoint
      * @throws InvalidResourceTypeException
      * @throws RequestTimeoutException
      */
+    /**
+     * Lists the page templates available in a data source.
+     *
+     * @param string|null $name filters templates by name
+     *
+     * @throws ApiResponseException
+     * @throws Exception
+     * @throws HttpResponseException
+     * @throws RequestTimeoutException
+     */
+    public function listTemplates(
+        string $dataSourceId,
+        ?string $name = null,
+        ?PaginationRequest $paginationRequest = null
+    ): DataSourceTemplateResults {
+        $paginationRequest = $paginationRequest ?? new PaginationRequest();
+
+        $query = array_merge(
+            $paginationRequest->toArray(),
+            $name !== null ? ['name' => $name] : [],
+        );
+
+        $requestParameters = (new RequestParameters())
+            ->setPath("data_sources/$dataSourceId/templates")
+            ->setQuery($query)
+            ->setMethod('GET');
+
+        $rawData = $this->getClient()->request($requestParameters);
+
+        return DataSourceTemplateResults::fromRawData($rawData);
+    }
+
     public function create(DataSource $dataSource): DataSource
     {
         $data = self::normalizeEmptyPropertyConfigurations($dataSource->toArray());

--- a/src/Resource/DataSource/DataSourceTemplate.php
+++ b/src/Resource/DataSource/DataSourceTemplate.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\DataSource;
+
+class DataSourceTemplate
+{
+    protected string $id = '';
+    protected string $name = '';
+    protected bool $isDefault = false;
+
+    public static function fromRawData(array $rawData): self
+    {
+        $template = new self();
+
+        $template->id = (string) ($rawData['id'] ?? '');
+        $template->name = (string) ($rawData['name'] ?? '');
+        $template->isDefault = (bool) ($rawData['is_default'] ?? false);
+
+        return $template;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+}

--- a/src/Resource/DataSource/DataSourceTemplateResults.php
+++ b/src/Resource/DataSource/DataSourceTemplateResults.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\NotionSdkPhp\Resource\DataSource;
+
+use function array_map;
+
+class DataSourceTemplateResults
+{
+    /**
+     * @var array|DataSourceTemplate[]
+     */
+    protected array $templates = [];
+    protected bool $hasMore = false;
+    protected ?string $nextCursor = null;
+
+    public static function fromRawData(array $rawData): self
+    {
+        $results = new self();
+
+        $results->templates = isset($rawData['templates']) ? array_map(
+            fn (array $templateRawData) => DataSourceTemplate::fromRawData($templateRawData),
+            (array) $rawData['templates'],
+        ) : [];
+        $results->hasMore = (bool) ($rawData['has_more'] ?? false);
+        $results->nextCursor = isset($rawData['next_cursor']) ? (string) $rawData['next_cursor'] : null;
+
+        return $results;
+    }
+
+    /**
+     * @return array|DataSourceTemplate[]
+     */
+    public function getTemplates(): array
+    {
+        return $this->templates;
+    }
+
+    public function isHasMore(): bool
+    {
+        return $this->hasMore;
+    }
+
+    public function getNextCursor(): ?string
+    {
+        return $this->nextCursor;
+    }
+}

--- a/tests/Endpoint/DataSourcesEndpointTest.php
+++ b/tests/Endpoint/DataSourcesEndpointTest.php
@@ -8,6 +8,8 @@ use Brd6\NotionSdkPhp\Client;
 use Brd6\NotionSdkPhp\ClientOptions;
 use Brd6\NotionSdkPhp\Endpoint\DataSourcesEndpoint;
 use Brd6\NotionSdkPhp\Resource\DataSource;
+use Brd6\NotionSdkPhp\Resource\DataSource\DataSourceTemplate;
+use Brd6\NotionSdkPhp\Resource\DataSource\DataSourceTemplateResults;
 use Brd6\NotionSdkPhp\Resource\Database\DatabaseRequest;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\TitlePropertyObject;
 use Brd6\NotionSdkPhp\Resource\Page;
@@ -154,5 +156,59 @@ class DataSourcesEndpointTest extends TestCase
 
         $this->assertSame('data_source', $created->getObject());
         $this->assertNotEmpty($created->getId());
+    }
+
+    public function testListTemplates(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('GET', $method);
+            $this->assertStringContainsString(
+                'data_sources/164b19c5-58e5-4a47-a3a9-c905d9519c65/templates',
+                $url,
+            );
+            $this->assertArrayNotHasKey('name', $options['query']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_list_templates_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $results = $client->dataSources()->listTemplates('164b19c5-58e5-4a47-a3a9-c905d9519c65');
+
+        $this->assertInstanceOf(DataSourceTemplateResults::class, $results);
+        $this->assertFalse($results->isHasMore());
+        $this->assertNull($results->getNextCursor());
+        $this->assertCount(2, $results->getTemplates());
+
+        $template = $results->getTemplates()[0];
+        $this->assertInstanceOf(DataSourceTemplate::class, $template);
+        $this->assertEquals('195de922-1179-449f-ab80-75a27c979105', $template->getId());
+        $this->assertEquals('Bug report', $template->getName());
+        $this->assertTrue($template->isDefault());
+        $this->assertFalse($results->getTemplates()[1]->isDefault());
+    }
+
+    public function testListTemplatesWithNameAndPagination(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertEquals('Bug report', $options['query']['name']);
+            $this->assertEquals(5, (int) $options['query']['page_size']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_list_templates_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $client->dataSources()->listTemplates(
+            '164b19c5-58e5-4a47-a3a9-c905d9519c65',
+            'Bug report',
+            (new PaginationRequest())->setPageSize(5),
+        );
     }
 }

--- a/tests/Fixtures/client_data_sources_list_templates_200.json
+++ b/tests/Fixtures/client_data_sources_list_templates_200.json
@@ -1,0 +1,16 @@
+{
+    "templates": [
+        {
+            "id": "195de922-1179-449f-ab80-75a27c979105",
+            "name": "Bug report",
+            "is_default": true
+        },
+        {
+            "id": "287ef033-228a-55a0-bc91-86b38d08a216",
+            "name": "Feature request",
+            "is_default": false
+        }
+    ],
+    "has_more": false,
+    "next_cursor": null
+}


### PR DESCRIPTION
## Description

Adds `dataSources()->listTemplates(string $dataSourceId, ?string $name = null, ?PaginationRequest $paginationRequest = null)` against `GET /v1/data_sources/{id}/templates`, mirroring the reference JavaScript SDK's `dataSources.listTemplates`:

- The response is a custom envelope (`templates`, `has_more`, `next_cursor` — not the standard list shape), hydrated into a `DataSourceTemplateResults` of typed `DataSourceTemplate` items (`id`, `name`, `isDefault()`).
- The optional `$name` query filters by template name; pagination uses the standard `PaginationRequest`.
- Template ids pair with `PageTemplate::templateId()` from #94 for applying a template to a page.

## Motivation and context

The January 2026 API changelog added template listing; it completes the template flow — without it, consumers cannot discover which template ids exist to apply.

## How has this been tested?

- New tests asserting the request path, the name/pagination query, and hydration of the custom envelope into typed items including the default flag.
- Verified live against the Notion API: listed a real data source's templates and hydrated its actual template ("New item", marked default).
- Full suite green (215 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
