### PR TITLE
fix(resource): drop read-only object and id from update payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Page, database, and data source update payloads no longer carry the read-only `object` and `id` fields. The API ignores them when well-formed but rejects updates on `2026-03-11` when the id was provided without hyphens, even though the same id works in the request path.
+
+## Unreleased
+
 ### Added
 
 - Add `dataSources()->listTemplates()` to list a data source's page templates (id, name, default flag), with pagination and a name filter — pairs with `PageTemplate::templateId()` for applying one.

--- a/src/Resource/DataSource.php
+++ b/src/Resource/DataSource.php
@@ -61,7 +61,11 @@ class DataSource extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        return $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+        $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+
+        unset($data['object'], $data['id']);
+
+        return $data;
     }
 
     /**

--- a/src/Resource/Database.php
+++ b/src/Resource/Database.php
@@ -66,6 +66,8 @@ class Database extends AbstractResource
     {
         $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
 
+        unset($data['object'], $data['id']);
+
         if ($this->isLocked === null) {
             unset($data['is_locked']);
         }

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -64,6 +64,8 @@ class Page extends AbstractResource
     {
         $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
 
+        unset($data['object'], $data['id']);
+
         if ($this->archived === null) {
             unset($data['archived']);
         }

--- a/tests/Endpoint/DatabasesEndpointTest.php
+++ b/tests/Endpoint/DatabasesEndpointTest.php
@@ -427,6 +427,8 @@ class DatabasesEndpointTest extends TestCase
             $this->assertArrayNotHasKey('properties', $body);
             $this->assertArrayNotHasKey('icon', $body);
             $this->assertArrayNotHasKey('cover', $body);
+            $this->assertArrayNotHasKey('object', $body);
+            $this->assertArrayNotHasKey('id', $body);
 
             return new MockResponseFactory(
                 (string) file_get_contents('tests/Fixtures/client_databases_update_database_200.json'),

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -292,8 +292,6 @@ class PagesEndpointTest extends TestCase
                 $body = json_decode($options['body'], true);
 
                 $expectedKeys = [
-                    'object',
-                    'id',
                     'created_time',
                     'created_by',
                     'last_edited_time',
@@ -681,6 +679,8 @@ class PagesEndpointTest extends TestCase
 
             $this->assertTrue($body['in_trash']);
             $this->assertArrayNotHasKey('archived', $body);
+            $this->assertArrayNotHasKey('object', $body);
+            $this->assertArrayNotHasKey('id', $body);
             $this->assertEquals(['2026-03-11'], $options['headers']['Notion-Version']);
 
             return new MockResponseFactory(


### PR DESCRIPTION
## Description

`toArrayForUpdate()` on `Page`, `Database`, and `DataSource` no longer includes the read-only `object` and `id` fields in update payloads. Neither is a documented update parameter; the API ignored them when well-formed, but on `2026-03-11` it validates `body.id` as a strict hyphenated UUID — so an update built with an un-hyphenated id (which the request path accepts) failed with `body.id should be a valid uuid`.

## Motivation and context

Notion ids are commonly handled without hyphens (URLs, copy-paste); a consumer calling `update()` with one gets a confusing validation error about a field they never set.

## How has this been tested?

- Existing update tests extended to assert `object`/`id` are absent; the retrieve-then-update payload-shape regression test's expected key list updated accordingly (its purpose — pinning the `archived` handling from #67 — is unchanged).
- Verified live against the Notion API on `2026-03-11`: the exact update call that previously failed with the un-hyphenated id now succeeds.
- Full suite green (215 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
