### PR TITLE
fix(resource): serialize only writable fields in update payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Fixed
-
-- Retrieve-then-update now works: update payloads for pages, databases, and data sources carry only the writable fields. Previously every hydrated field leaked into the body — computed property values (formula, rollup, created/edited metadata), null-valued properties serialized as empty arrays, and read-only top-level fields like `created_time` — which the API rejects, so updating a retrieved resource always failed.
-
-## Unreleased
-
-### Fixed
-
-- Page, database, and data source update payloads no longer carry the read-only `object` and `id` fields. The API ignores them when well-formed but rejects updates on `2026-03-11` when the id was provided without hyphens, even though the same id works in the request path.
-
-## Unreleased
-
 ### Added
 
 - Add `dataSources()->listTemplates()` to list a data source's page templates (id, name, default flag), with pagination and a name filter — pairs with `PageTemplate::templateId()` for applying one.
 - Add page template support: an optional `PageTemplate` on `pages()->create()` and `update()` applies a data source's default template or a specific template (`PageTemplate::none()`, `::defaultTemplate()`, `::templateId()`, with an optional timezone for relative dates), and an optional `$eraseContent` flag on `update()` clears existing page content.
 - Add an optional `PagePosition` to `pages()->create()`, `createFromMarkdown()`, and `createFromMarkdownAsync()` to place the new page at the start or end of its parent or after a specific block (`PagePosition::pageStart()`, `::pageEnd()`, `::afterBlock()`).
 - Add `pages()->move()` to move a page under a new page or data source parent.
+
+### Fixed
+
+- Retrieve-then-update now works: update payloads for pages, databases, and data sources carry only the writable fields. Previously every hydrated field leaked into the body — computed property values (formula, rollup, created/edited metadata), null-valued properties serialized as empty arrays, and read-only top-level fields like `created_time` — which the API rejects, so updating a retrieved resource always failed. This subsumes the earlier removal of the read-only `object` and `id` fields, which the `2026-03-11` API rejects when the id was provided without hyphens.
 
 ## 1.11.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Retrieve-then-update now works: update payloads for pages, databases, and data sources carry only the writable fields. Previously every hydrated field leaked into the body — computed property values (formula, rollup, created/edited metadata), null-valued properties serialized as empty arrays, and read-only top-level fields like `created_time` — which the API rejects, so updating a retrieved resource always failed.
+
+## Unreleased
+
+### Fixed
+
 - Page, database, and data source update payloads no longer carry the read-only `object` and `id` fields. The API ignores them when well-formed but rejects updates on `2026-03-11` when the id was provided without hyphens, even though the same id works in the request path.
 
 ## Unreleased

--- a/src/Resource/DataSource.php
+++ b/src/Resource/DataSource.php
@@ -61,11 +61,7 @@ class DataSource extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
-
-        unset($data['object'], $data['id']);
-
-        return $data;
+        return $this->toArrayStrict(self::UPDATE_ACCEPTED_KEYS);
     }
 
     /**

--- a/src/Resource/Database.php
+++ b/src/Resource/Database.php
@@ -64,15 +64,7 @@ class Database extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
-
-        unset($data['object'], $data['id']);
-
-        if ($this->isLocked === null) {
-            unset($data['is_locked']);
-        }
-
-        return $data;
+        return $this->toArrayStrict(self::UPDATE_ACCEPTED_KEYS);
     }
 
     /**

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -15,6 +15,7 @@ use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\AbstractPropertyValue;
 use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
+use Brd6\NotionSdkPhp\Util\StringHelper;
 use DateTimeImmutable;
 
 use function array_diff_key;
@@ -90,13 +91,16 @@ class Page extends AbstractResource
         }
 
         foreach ($this->properties as $name => $propertyValue) {
+            // toArray() snake_cases array keys, including the property names.
+            $serializedName = StringHelper::camelCaseToSnakeCase($name);
+
             if (in_array($propertyValue->getType(), self::READ_ONLY_PROPERTY_VALUE_TYPES, true)) {
-                unset($data['properties'][$name]);
+                unset($data['properties'][$serializedName]);
 
                 continue;
             }
 
-            $serialized = $data['properties'][$name] ?? null;
+            $serialized = $data['properties'][$serializedName] ?? null;
 
             if (!is_array($serialized)) {
                 continue;
@@ -112,7 +116,7 @@ class Page extends AbstractResource
             }
 
             if (!$hasValue) {
-                unset($data['properties'][$name]);
+                unset($data['properties'][$serializedName]);
             }
         }
 

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -79,9 +79,6 @@ class Page extends AbstractResource
     }
 
     /**
-     * The API rejects computed property values in create and update payloads, and a
-     * property hydrated with a null value serializes without a usable value key.
-     *
      * @psalm-suppress MixedAssignment
      */
     private function removeReadOnlyPropertyValues(array $data): array
@@ -91,7 +88,6 @@ class Page extends AbstractResource
         }
 
         foreach ($this->properties as $name => $propertyValue) {
-            // toArray() snake_cases array keys, including the property names.
             $serializedName = StringHelper::camelCaseToSnakeCase($name);
 
             if (in_array($propertyValue->getType(), self::READ_ONLY_PROPERTY_VALUE_TYPES, true)) {

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -17,13 +17,25 @@ use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\AbstractPropertyValue;
 use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
 use DateTimeImmutable;
 
+use function array_diff_key;
 use function array_key_exists;
+use function in_array;
+use function is_array;
 
 class Page extends AbstractResource
 {
     public const RESOURCE_TYPE = 'page';
     private const CREATE_ACCEPTED_KEYS = ['object', 'properties', 'parent', 'icon', 'cover'];
     private const UPDATE_ACCEPTED_KEYS = ['properties', 'archived', 'icon', 'cover', 'is_locked'];
+    private const READ_ONLY_PROPERTY_VALUE_TYPES = [
+        'created_by',
+        'created_time',
+        'last_edited_by',
+        'last_edited_time',
+        'formula',
+        'rollup',
+        'unique_id',
+    ];
 
     protected ?DateTimeImmutable $createdTime = null;
     protected ?UserInterface $createdBy = null;
@@ -51,7 +63,7 @@ class Page extends AbstractResource
 
     public function toArrayForCreate(): array
     {
-        $data = $this->toArrayStrict(self::CREATE_ACCEPTED_KEYS);
+        $data = $this->removeReadOnlyPropertyValues($this->toArrayStrict(self::CREATE_ACCEPTED_KEYS));
 
         if ($this->archived !== null) {
             $data['archived'] = $this->archived;
@@ -62,16 +74,46 @@ class Page extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        $data = $this->toArray(true, self::UPDATE_ACCEPTED_KEYS);
+        return $this->removeReadOnlyPropertyValues($this->toArrayStrict(self::UPDATE_ACCEPTED_KEYS));
+    }
 
-        unset($data['object'], $data['id']);
-
-        if ($this->archived === null) {
-            unset($data['archived']);
+    /**
+     * The API rejects computed property values in create and update payloads, and a
+     * property hydrated with a null value serializes without a usable value key.
+     *
+     * @psalm-suppress MixedAssignment
+     */
+    private function removeReadOnlyPropertyValues(array $data): array
+    {
+        if (!isset($data['properties']) || !is_array($data['properties'])) {
+            return $data;
         }
 
-        if ($this->isLocked === null) {
-            unset($data['is_locked']);
+        foreach ($this->properties as $name => $propertyValue) {
+            if (in_array($propertyValue->getType(), self::READ_ONLY_PROPERTY_VALUE_TYPES, true)) {
+                unset($data['properties'][$name]);
+
+                continue;
+            }
+
+            $serialized = $data['properties'][$name] ?? null;
+
+            if (!is_array($serialized)) {
+                continue;
+            }
+
+            $hasValue = false;
+            foreach (array_diff_key($serialized, ['id' => true, 'type' => true]) as $value) {
+                if ($value !== null && $value !== []) {
+                    $hasValue = true;
+
+                    break;
+                }
+            }
+
+            if (!$hasValue) {
+                unset($data['properties'][$name]);
+            }
         }
 
         return $data;

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -292,16 +292,8 @@ class PagesEndpointTest extends TestCase
                 $body = json_decode($options['body'], true);
 
                 $expectedKeys = [
-                    'created_time',
-                    'created_by',
-                    'last_edited_time',
-                    'last_edited_by',
                     'archived',
-                    'icon',
-                    'cover',
                     'properties',
-                    'parent',
-                    'url',
                 ];
 
                 $actualKeys = array_keys($body);

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -231,6 +231,8 @@ class PageTest extends TestCase
         $this->assertArrayNotHasKey('Created', $properties);
         $this->assertArrayNotHasKey('Last Edited Time', $properties);
         $this->assertArrayNotHasKey('Last Edited By', $properties);
+        $this->assertArrayNotHasKey('formula_2', $properties);
+        $this->assertArrayNotHasKey('formula_test_1', $properties);
         $this->assertArrayNotHasKey('formula2', $properties);
         $this->assertArrayNotHasKey('formulaTest1', $properties);
     }
@@ -268,6 +270,7 @@ class PageTest extends TestCase
         $properties = $page->toArrayForCreate()['properties'];
 
         $this->assertArrayHasKey('Name', $properties);
+        $this->assertArrayNotHasKey('formula_2', $properties);
         $this->assertArrayNotHasKey('formula2', $properties);
         $this->assertArrayNotHasKey('Created By', $properties);
     }

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -211,6 +211,67 @@ class PageTest extends TestCase
         $this->assertTrue($page->toArrayForUpdate()['is_locked']);
     }
 
+    public function testUpdateSerializationOmitsReadOnlyPropertyValues(): void
+    {
+        /** @var Page $page */
+        $page = Page::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_properties_200.json'),
+                true,
+            ),
+        );
+
+        $properties = $page->toArrayForUpdate()['properties'];
+
+        $this->assertArrayHasKey('Name', $properties);
+        $this->assertArrayHasKey('Status', $properties);
+        $this->assertArrayHasKey('My number', $properties);
+        $this->assertArrayHasKey('Stakeholders', $properties);
+        $this->assertArrayNotHasKey('Created By', $properties);
+        $this->assertArrayNotHasKey('Created', $properties);
+        $this->assertArrayNotHasKey('Last Edited Time', $properties);
+        $this->assertArrayNotHasKey('Last Edited By', $properties);
+        $this->assertArrayNotHasKey('formula2', $properties);
+        $this->assertArrayNotHasKey('formulaTest1', $properties);
+    }
+
+    public function testUpdateSerializationOmitsValuelessPropertyValues(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_properties_200.json'),
+            true,
+        );
+        $rawData['properties']['Type']['select'] = null;
+        $rawData['properties']['My number']['number'] = null;
+
+        /** @var Page $page */
+        $page = Page::fromRawData($rawData);
+
+        $properties = $page->toArrayForUpdate()['properties'];
+
+        $this->assertArrayNotHasKey('Type', $properties);
+        $this->assertArrayNotHasKey('My number', $properties);
+        $this->assertArrayHasKey('Status', $properties);
+        $this->assertArrayHasKey('Name', $properties);
+    }
+
+    public function testCreateSerializationOmitsReadOnlyPropertyValues(): void
+    {
+        /** @var Page $page */
+        $page = Page::fromRawData(
+            (array) json_decode(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_properties_200.json'),
+                true,
+            ),
+        );
+
+        $properties = $page->toArrayForCreate()['properties'];
+
+        $this->assertArrayHasKey('Name', $properties);
+        $this->assertArrayNotHasKey('formula2', $properties);
+        $this->assertArrayNotHasKey('Created By', $properties);
+    }
+
     public function testPageIsArchivedReturnsFalseWhenUnset(): void
     {
         $page = new Page();


### PR DESCRIPTION
## Description

Fixes retrieve-then-update, which never worked against the live API on any version: update payloads carried every hydrated field, and the API rejects several of them.

- `toArrayForUpdate()` on `Page`, `Database`, and `DataSource` is now strict on the accepted update keys, instead of force-including them alongside every other non-empty field. This stops read-only top-level metadata leaking into bodies — `created_time` (which serialized as a date object and always failed validation), `created_by`, `last_edited_*`, `url`, `parent` — and subsumes the earlier `object`/`id` and null `icon`/`cover` special-casing.
- Page payloads additionally drop computed property values the API refuses (`created_by`, `created_time`, `last_edited_by`, `last_edited_time`, `formula`, `rollup`, `unique_id` — `verification` stays, being writable on wiki pages) and properties hydrated with a null value, whose serialized form carries no usable value (`"date": null` became `"date": []`). The filter resolves property names through the same snake_case key transform serialization applies, so camelCase-named properties are covered.
- Explicitly set values still serialize, including `false` (`archived`, `is_locked`) and `0`; the `archived: false` round-trip behavior from #67 is preserved and still pinned.

## Motivation and context

The natural "retrieve, mutate, update" flow failed with confusing validation errors on any real-world page (anything with computed or empty properties) — for example `body.properties.Last edited by.title should be defined` or `body.created_time should be a string`.

## How has this been tested?

- New tests: computed property values dropped from update and create payloads (asserted under the transformed key names so they cannot pass vacuously), null-valued properties dropped, writable properties kept; the retrieve-then-update payload-shape test updated to the strict contract with its `archived: false` assertion intact.
- Verified live against the Notion API: retrieve-then-update now succeeds for a page (on both `2022-06-28` and `2026-03-11`), a database row with a full property set, and a database — all of which failed before the change.
- An adversarial review pass caught the property-name transform mismatch, fixed and re-verified.
- Full suite green (218 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

Known remaining edge (separate issue): a *data source* schema round-trip still fails on computed property configurations, and camelCase-named properties are renamed by the payload key transform — both pre-existing and tracked separately.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
