### PR TITLE
fix(serialization): preserve user-defined property names in payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Property names are no longer snake_cased in request payloads. A property named `myField` was silently renamed to `my_field` when writing page values or database schemas, so the API either rejected the write or targeted the wrong property.
+
 ## 1.12.0 - 2026-07-14
 
 ### Added

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -15,7 +15,6 @@ use Brd6\NotionSdkPhp\Resource\File\AbstractFile;
 use Brd6\NotionSdkPhp\Resource\Page\Parent\AbstractParentProperty;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\AbstractPropertyValue;
 use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
-use Brd6\NotionSdkPhp\Util\StringHelper;
 use DateTimeImmutable;
 
 use function array_diff_key;
@@ -88,15 +87,13 @@ class Page extends AbstractResource
         }
 
         foreach ($this->properties as $name => $propertyValue) {
-            $serializedName = StringHelper::camelCaseToSnakeCase($name);
-
             if (in_array($propertyValue->getType(), self::READ_ONLY_PROPERTY_VALUE_TYPES, true)) {
-                unset($data['properties'][$serializedName]);
+                unset($data['properties'][$name]);
 
                 continue;
             }
 
-            $serialized = $data['properties'][$serializedName] ?? null;
+            $serialized = $data['properties'][$name] ?? null;
 
             if (!is_array($serialized)) {
                 continue;
@@ -112,7 +109,7 @@ class Page extends AbstractResource
             }
 
             if (!$hasValue) {
-                unset($data['properties'][$serializedName]);
+                unset($data['properties'][$name]);
             }
         }
 

--- a/src/Util/ArrayHelper.php
+++ b/src/Util/ArrayHelper.php
@@ -21,10 +21,32 @@ class ArrayHelper
             $transformedKey = StringHelper::camelCaseToSnakeCase((string) $key);
 
             if (is_array($value)) {
-                self::transformKeysToSnakeCase($value);
+                if ($transformedKey === 'properties') {
+                    self::transformChildValueKeysToSnakeCase($value);
+                } else {
+                    self::transformKeysToSnakeCase($value);
+                }
             }
 
             $data[$transformedKey] = $value;
+            unset($value);
+        }
+    }
+
+    /**
+     * Keys of a `properties` map are user-defined property names, not fields to transform.
+     *
+     * @psalm-suppress MixedAssignment
+     */
+    private static function transformChildValueKeysToSnakeCase(array &$data): void
+    {
+        foreach (array_keys($data) as $key) {
+            $value = &$data[$key];
+
+            if (is_array($value)) {
+                self::transformKeysToSnakeCase($value);
+            }
+
             unset($value);
         }
     }

--- a/tests/Endpoint/PagesEndpointTest.php
+++ b/tests/Endpoint/PagesEndpointTest.php
@@ -28,6 +28,7 @@ use Brd6\NotionSdkPhp\Resource\Page\PropertyItem\TitlePropertyItem;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\AbstractPropertyValue;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\DatePropertyValue;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\FilesPropertyValue;
+use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\RichTextPropertyValue;
 use Brd6\NotionSdkPhp\Resource\Page\PropertyValue\TitlePropertyValue;
 use Brd6\NotionSdkPhp\Resource\Pagination\AbstractPaginationResults;
 use Brd6\NotionSdkPhp\Resource\Pagination\PropertyItemResults;
@@ -965,6 +966,36 @@ class PagesEndpointTest extends TestCase
         $page = new Page();
         $page->setId('1e7e638f78864ec591ea54ec7016e146');
         $page->setArchived(true);
+
+        $client->pages()->update($page);
+    }
+
+    public function testUpdatePagePreservesCamelCasePropertyNames(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('myCamelField', $body['properties']);
+            $this->assertArrayNotHasKey('my_camel_field', $body['properties']);
+            $this->assertEquals(
+                'hello',
+                $body['properties']['myCamelField']['rich_text'][0]['text']['content'],
+            );
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_pages_retrieve_page_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $page = new Page();
+        $page->setId('1e7e638f78864ec591ea54ec7016e146');
+        $page->setProperties([
+            'myCamelField' => (new RichTextPropertyValue())->setRichText([Text::fromContent('hello')]),
+        ]);
 
         $client->pages()->update($page);
     }

--- a/tests/Resource/PageTest.php
+++ b/tests/Resource/PageTest.php
@@ -231,10 +231,10 @@ class PageTest extends TestCase
         $this->assertArrayNotHasKey('Created', $properties);
         $this->assertArrayNotHasKey('Last Edited Time', $properties);
         $this->assertArrayNotHasKey('Last Edited By', $properties);
-        $this->assertArrayNotHasKey('formula_2', $properties);
-        $this->assertArrayNotHasKey('formula_test_1', $properties);
         $this->assertArrayNotHasKey('formula2', $properties);
         $this->assertArrayNotHasKey('formulaTest1', $properties);
+        $this->assertArrayNotHasKey('formula_2', $properties);
+        $this->assertArrayNotHasKey('formula_test_1', $properties);
     }
 
     public function testUpdateSerializationOmitsValuelessPropertyValues(): void


### PR DESCRIPTION
## Description

Serialization snake_cases array keys so the SDK's camelCase fields become the API's snake_case ones — but it applied the transform to *every* key, including the keys of `properties` maps, which are user-defined property names. A Notion property named `myField` was silently renamed to `my_field` in write payloads (page property values, database and data source schemas), so the API either rejected the write or targeted a different property. Names with spaces or plain lowercase were unaffected, which is why the bug stayed hidden.

`ArrayHelper::transformKeysToSnakeCase()` now preserves the immediate child keys of a `properties` key while still transforming the structures beneath them (rich text annotations, select options, and so on). The page write filter from #97 goes back to plain name lookups accordingly.

## Motivation and context

Any database with camelCase or letter-digit column names (`myField`, `formula2`) was unwritable through the SDK — page creation, property updates, and schema updates all sent the wrong property name.

## How has this been tested?

- New test: a page update keyed by `myCamelField` serializes under exactly that name, with the value's nested keys still transformed; the #97 filter tests now assert the raw property names.
- Verified live against the Notion API: added a `myCamelField` column to a real data source through `dataSources()->update()` (created with the exact name — previously it appeared as `my_camel_field`), created a page writing a value to it, read the value back, then removed the test column.
- Full suite green (219 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
