### PR TITLE
fix(data-sources): make schema round-trips writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Data source retrieve-then-update now works: schema update payloads drop the computed property configurations the API refuses (created/edited metadata columns), and hydrated empty property configurations serialize as `{}` instead of `[]`.
 - Property names are no longer snake_cased in request payloads. A property named `myField` was silently renamed to `my_field` when writing page values or database schemas, so the API either rejected the write or targeted the wrong property.
 
 ## 1.12.0 - 2026-07-14

--- a/src/Endpoint/AbstractEndpoint.php
+++ b/src/Endpoint/AbstractEndpoint.php
@@ -68,13 +68,17 @@ abstract class AbstractEndpoint
             }
 
             $propertyConfigKeys = array_keys($propertyRawData);
-            if (count($propertyConfigKeys) !== 1) {
+
+            if (count($propertyConfigKeys) === 1) {
+                $propertyConfigKey = (string) $propertyConfigKeys[0];
+            } elseif (isset($propertyRawData['type'])) {
+                $propertyConfigKey = (string) $propertyRawData['type'];
+            } else {
                 $data['properties'][$propertyName] = $propertyRawData;
 
                 continue;
             }
 
-            $propertyConfigKey = (string) $propertyConfigKeys[0];
             if (($propertyRawData[$propertyConfigKey] ?? null) === []) {
                 $propertyRawData[$propertyConfigKey] = new stdClass();
             }

--- a/src/Resource/DataSource.php
+++ b/src/Resource/DataSource.php
@@ -19,11 +19,19 @@ use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
 use DateTimeImmutable;
 
 use function array_map;
+use function in_array;
+use function is_array;
 
 class DataSource extends AbstractResource
 {
     public const RESOURCE_TYPE = 'data_source';
     private const UPDATE_ACCEPTED_KEYS = ['title', 'properties', 'in_trash'];
+    private const READ_ONLY_PROPERTY_CONFIGURATION_TYPES = [
+        'created_by',
+        'created_time',
+        'last_edited_by',
+        'last_edited_time',
+    ];
 
     protected ?DateTimeImmutable $createdTime = null;
     protected ?UserInterface $createdBy = null;
@@ -61,7 +69,19 @@ class DataSource extends AbstractResource
 
     public function toArrayForUpdate(): array
     {
-        return $this->toArrayStrict(self::UPDATE_ACCEPTED_KEYS);
+        $data = $this->toArrayStrict(self::UPDATE_ACCEPTED_KEYS);
+
+        if (!isset($data['properties']) || !is_array($data['properties'])) {
+            return $data;
+        }
+
+        foreach ($this->properties as $name => $propertyObject) {
+            if (in_array($propertyObject->getType(), self::READ_ONLY_PROPERTY_CONFIGURATION_TYPES, true)) {
+                unset($data['properties'][$name]);
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/tests/Endpoint/DataSourcesEndpointTest.php
+++ b/tests/Endpoint/DataSourcesEndpointTest.php
@@ -211,4 +211,35 @@ class DataSourcesEndpointTest extends TestCase
             (new PaginationRequest())->setPageSize(5),
         );
     }
+
+    public function testUpdateNormalizesHydratedEmptyPropertyConfigurations(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame([], $body['properties']['Date']['date']);
+            $this->assertStringContainsString('"date":{}', $options['body']);
+            $this->assertArrayNotHasKey('Last edited by', $body['properties']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        );
+        $rawData['properties']['Date'] = ['id' => 'a1', 'name' => 'Date', 'type' => 'date', 'date' => []];
+        $rawData['properties']['Last edited by'] = ['id' => 'b2', 'name' => 'Last edited by', 'type' => 'last_edited_by', 'last_edited_by' => []];
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData($rawData);
+
+        $client->dataSources()->update($dataSource);
+    }
 }

--- a/tests/Resource/DataSourceTest.php
+++ b/tests/Resource/DataSourceTest.php
@@ -25,6 +25,26 @@ class DataSourceTest extends TestCase
         DataSource::fromRawData([]);
     }
 
+    public function testUpdateSerializationOmitsReadOnlyPropertyConfigurations(): void
+    {
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        );
+        $rawData['properties']['Created time'] = ['id' => 'a1', 'name' => 'Created time', 'type' => 'created_time', 'created_time' => []];
+        $rawData['properties']['Last edited by'] = ['id' => 'b2', 'name' => 'Last edited by', 'type' => 'last_edited_by', 'last_edited_by' => []];
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData($rawData);
+
+        $properties = $dataSource->toArrayForUpdate()['properties'];
+
+        $this->assertArrayHasKey('Name', $properties);
+        $this->assertArrayHasKey('Projects', $properties);
+        $this->assertArrayNotHasKey('Created time', $properties);
+        $this->assertArrayNotHasKey('Last edited by', $properties);
+    }
+
     public function testDataSourceHydratesInTrashPayloadWithoutArchivedKey(): void
     {
         $rawData = (array) json_decode(


### PR DESCRIPTION
## Description

Completes the retrieve-then-update story for data sources (the schema-level counterpart of #97):

- `DataSource::toArrayForUpdate()` drops computed property configurations — `created_by`, `created_time`, `last_edited_by`, `last_edited_time` columns — which the Update Data Source API refuses (`"Last edited by is not a valid property schema"`).
- `normalizeEmptyPropertyConfigurations()` now also recognizes hydrated configuration shapes: it previously converted empty configs to `{}` only for hand-built single-key configs, so a retrieved `date` column serialized its empty config as `[]` and failed validation. The config key is now resolved from the `type` field when present.

## Motivation and context

Programmatic schema editing by retrieve-modify-update — adding or renaming a column — failed on any data source with a computed or empty-config column, which is nearly all real ones.

## How has this been tested?

- New tests: computed configurations dropped from update payloads; a hydrated empty `date` config serializes as `{}` (asserted on the raw JSON) while computed columns stay filtered.
- Verified live against the Notion API: retrieve-then-update of a real data source (computed columns plus `date`, `select`, and `title`) previously failed and now succeeds with the schema intact.
- Full suite green (221 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

Builds on #98 (property names preserved in payloads); the diff shown includes it until that merges.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
