### PR TITLE
fix(serialization): objectify nested empty relation configs in schema payloads

### DIFF
--- a/src/Endpoint/AbstractEndpoint.php
+++ b/src/Endpoint/AbstractEndpoint.php
@@ -54,6 +54,14 @@ abstract class AbstractEndpoint
     }
 
     /**
+     * Object-valued nested config keys that Notion rejects when serialized as `[]` instead of `{}`.
+     * Keyed by the parent config key; list-valued siblings such as `options` and `groups` are never touched.
+     */
+    private const NESTED_OBJECT_CONFIG_KEYS = [
+        'relation' => ['single_property', 'dual_property'],
+    ];
+
+    /**
      * @psalm-suppress MixedAssignment
      */
     protected static function normalizeEmptyPropertyConfigurations(array $data): array
@@ -79,13 +87,31 @@ abstract class AbstractEndpoint
                 continue;
             }
 
-            if (($propertyRawData[$propertyConfigKey] ?? null) === []) {
+            $config = $propertyRawData[$propertyConfigKey] ?? null;
+
+            if ($config === []) {
                 $propertyRawData[$propertyConfigKey] = new stdClass();
+            } elseif (is_array($config)) {
+                $propertyRawData[$propertyConfigKey] = self::normalizeNestedEmptyConfig($propertyConfigKey, $config);
             }
 
             $data['properties'][$propertyName] = $propertyRawData;
         }
 
         return $data;
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    private static function normalizeNestedEmptyConfig(string $configKey, array $config): array
+    {
+        foreach (self::NESTED_OBJECT_CONFIG_KEYS[$configKey] ?? [] as $nestedKey) {
+            if (($config[$nestedKey] ?? null) === []) {
+                $config[$nestedKey] = new stdClass();
+            }
+        }
+
+        return $config;
     }
 }

--- a/src/Endpoint/DatabasesEndpoint.php
+++ b/src/Endpoint/DatabasesEndpoint.php
@@ -18,6 +18,7 @@ use Brd6\NotionSdkPhp\Resource\Database\DatabaseRequest;
 use Brd6\NotionSdkPhp\Resource\Pagination\AbstractPaginationResults;
 use Brd6\NotionSdkPhp\Resource\Pagination\PaginationRequest;
 use Http\Client\Exception;
+use stdClass;
 
 use function array_merge;
 
@@ -70,8 +71,9 @@ class DatabasesEndpoint extends AbstractEndpoint
         $data = $database->toArray();
 
         if ($this->supportsVersion(ClientOptions::NOTION_VERSION_2025_09_03)) {
+            $properties = (array) ($data['properties'] ?? []);
             $data['initial_data_source'] = [
-                'properties' => (array) ($data['properties'] ?? []),
+                'properties' => $properties === [] ? new stdClass() : $properties,
             ];
             $data['initial_data_source'] = self::normalizeEmptyPropertyConfigurations($data['initial_data_source']);
             unset($data['properties']);

--- a/src/Resource/Database/PropertyConfiguration/RelationPropertyConfiguration.php
+++ b/src/Resource/Database/PropertyConfiguration/RelationPropertyConfiguration.php
@@ -6,10 +6,18 @@ namespace Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration;
 
 use Brd6\NotionSdkPhp\Resource\Property\AbstractProperty;
 
+use function in_array;
+
 class RelationPropertyConfiguration extends AbstractProperty
 {
+    public const TYPE_SINGLE_PROPERTY = 'single_property';
+    public const TYPE_DUAL_PROPERTY = 'dual_property';
+
     protected string $databaseId = '';
     protected string $dataSourceId = '';
+    protected ?string $type = null;
+    protected ?array $singleProperty = null;
+    protected ?array $dualProperty = null;
     protected ?string $syncedPropertyName = null;
     protected ?string $syncedPropertyId = null;
 
@@ -19,6 +27,9 @@ class RelationPropertyConfiguration extends AbstractProperty
 
         $property->databaseId = (string) ($rawData['database_id'] ?? '');
         $property->dataSourceId = (string) ($rawData['data_source_id'] ?? '');
+        $property->singleProperty = ($rawData['single_property'] ?? null) === [] ? [] : null;
+        $property->dualProperty = ($rawData['dual_property'] ?? null) === [] ? [] : null;
+        $property->type = $property->resolveType($rawData);
         $dualProperty = (array) ($rawData['dual_property'] ?? []);
         $property->syncedPropertyName = isset($rawData['synced_property_name']) ?
             (string) $rawData['synced_property_name'] :
@@ -60,6 +71,39 @@ class RelationPropertyConfiguration extends AbstractProperty
         return $this;
     }
 
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function getSingleProperty(): ?array
+    {
+        return $this->singleProperty;
+    }
+
+    public function getDualProperty(): ?array
+    {
+        return $this->dualProperty;
+    }
+
+    public function setSinglePropertyRelation(): self
+    {
+        $this->type = self::TYPE_SINGLE_PROPERTY;
+        $this->singleProperty = [];
+        $this->dualProperty = null;
+
+        return $this;
+    }
+
+    public function setDualPropertyRelation(): self
+    {
+        $this->type = self::TYPE_DUAL_PROPERTY;
+        $this->dualProperty = [];
+        $this->singleProperty = null;
+
+        return $this;
+    }
+
     public function getSyncedPropertyName(): ?string
     {
         return $this->syncedPropertyName;
@@ -82,5 +126,43 @@ class RelationPropertyConfiguration extends AbstractProperty
         $this->syncedPropertyId = $syncedPropertyId;
 
         return $this;
+    }
+
+    private function resolveType(array $rawData): ?string
+    {
+        if (isset($rawData['type'])) {
+            return (string) $rawData['type'];
+        }
+
+        if (isset($rawData['single_property'])) {
+            return self::TYPE_SINGLE_PROPERTY;
+        }
+
+        if (isset($rawData['dual_property'])) {
+            return self::TYPE_DUAL_PROPERTY;
+        }
+
+        return null;
+    }
+
+    private function hasEmptyRelationMarker(): bool
+    {
+        return $this->singleProperty === [] || $this->dualProperty === [];
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function canBeSerialized($value, string $key): bool
+    {
+        if (in_array($key, ['singleProperty', 'dualProperty'], true)) {
+            return $value === [];
+        }
+
+        if ($key === 'type') {
+            return $this->hasEmptyRelationMarker();
+        }
+
+        return parent::canBeSerialized($value, $key);
     }
 }

--- a/tests/Endpoint/DataSourcesEndpointTest.php
+++ b/tests/Endpoint/DataSourcesEndpointTest.php
@@ -242,4 +242,117 @@ class DataSourcesEndpointTest extends TestCase
 
         $client->dataSources()->update($dataSource);
     }
+
+    public function testUpdateObjectifiesHydratedSinglePropertyRelation(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['properties']['Project']['relation'];
+            $this->assertSame('single_property', $relation['type']);
+            $this->assertSame([], $relation['single_property']);
+            $this->assertSame('target-ds', $relation['data_source_id']);
+            $this->assertStringContainsString('"single_property":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"single_property":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        );
+        $rawData['properties']['Project'] = [
+            'id' => 'p1',
+            'name' => 'Project',
+            'type' => 'relation',
+            'relation' => [
+                'data_source_id' => 'target-ds',
+                'type' => 'single_property',
+                'single_property' => [],
+            ],
+        ];
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData($rawData);
+
+        $client->dataSources()->update($dataSource);
+    }
+
+    public function testUpdateKeepsPopulatedRelationFlatWithoutNestedObject(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['properties']['Projects']['relation'];
+            $this->assertArrayNotHasKey('single_property', $relation);
+            $this->assertArrayNotHasKey('dual_property', $relation);
+            $this->assertArrayNotHasKey('type', $relation);
+            $this->assertSame('Tasks', $relation['synced_property_name']);
+            $this->assertStringNotContainsString('"dual_property":', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData((array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        ));
+
+        $client->dataSources()->update($dataSource);
+    }
+
+    public function testUpdateObjectifiesHydratedDualPropertyRelation(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['properties']['Project']['relation'];
+            $this->assertSame('dual_property', $relation['type']);
+            $this->assertSame([], $relation['dual_property']);
+            $this->assertStringContainsString('"dual_property":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"dual_property":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $rawData = (array) json_decode(
+            (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+            true,
+        );
+        $rawData['properties']['Project'] = [
+            'id' => 'p1',
+            'name' => 'Project',
+            'type' => 'relation',
+            'relation' => [
+                'data_source_id' => 'target-ds',
+                'type' => 'dual_property',
+                'dual_property' => [],
+            ],
+        ];
+
+        /** @var DataSource $dataSource */
+        $dataSource = DataSource::fromRawData($rawData);
+
+        $client->dataSources()->update($dataSource);
+    }
 }

--- a/tests/Endpoint/DatabasesEndpointTest.php
+++ b/tests/Endpoint/DatabasesEndpointTest.php
@@ -10,6 +10,7 @@ use Brd6\NotionSdkPhp\Endpoint\DatabasesEndpoint;
 use Brd6\NotionSdkPhp\Resource\Database;
 use Brd6\NotionSdkPhp\Resource\Database\DatabaseRequest;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration\NumberPropertyConfiguration;
+use Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration\RelationPropertyConfiguration;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyConfiguration\SelectPropertyConfiguration;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\CheckboxPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\DatePropertyObject;
@@ -17,6 +18,7 @@ use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\FilesPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\MultiSelectPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\NumberPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\PeoplePropertyObject;
+use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\RelationPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\RichTextPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\SelectPropertyObject;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\TitlePropertyObject;
@@ -455,5 +457,161 @@ class DatabasesEndpointTest extends TestCase
         $database->setProperties(['in stock' => $inStockSelectObject]);
 
         $client->databases()->update($database);
+    }
+
+    public function testCreateObjectifiesSinglePropertyRelationInInitialDataSource(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['initial_data_source']['properties']['Project']['relation'];
+            $this->assertSame('single_property', $relation['type']);
+            $this->assertSame([], $relation['single_property']);
+            $this->assertStringContainsString('"single_property":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"single_property":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_databases_create_database_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2025_09_03)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $relationObject = new RelationPropertyObject();
+        $relationObject->setRelation(
+            (new RelationPropertyConfiguration())
+                ->setDataSourceId('248104cd-477e-80fd-b757-e945d38000bd')
+                ->setSinglePropertyRelation(),
+        );
+
+        $database = new Database();
+        $database->setParent((new PageIdParent())->setPageId('4a808e6e88454d49a447fb2a4c460f6f'));
+        $database->setTitle([Text::fromContent('Tasks')]);
+        $database->setProperties([
+            'name' => new TitlePropertyObject(),
+            'Project' => $relationObject,
+        ]);
+
+        $client->databases()->create($database);
+    }
+
+    public function testCreateObjectifiesDualPropertyRelationInInitialDataSource(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['initial_data_source']['properties']['Project']['relation'];
+            $this->assertSame('dual_property', $relation['type']);
+            $this->assertSame([], $relation['dual_property']);
+            $this->assertStringContainsString('"dual_property":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"dual_property":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_databases_create_database_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2025_09_03)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $relationObject = new RelationPropertyObject();
+        $relationObject->setRelation(
+            (new RelationPropertyConfiguration())
+                ->setDataSourceId('248104cd-477e-80fd-b757-e945d38000bd')
+                ->setDualPropertyRelation(),
+        );
+
+        $database = new Database();
+        $database->setParent((new PageIdParent())->setPageId('4a808e6e88454d49a447fb2a4c460f6f'));
+        $database->setTitle([Text::fromContent('Tasks')]);
+        $database->setProperties([
+            'name' => new TitlePropertyObject(),
+            'Project' => $relationObject,
+        ]);
+
+        $client->databases()->create($database);
+    }
+
+    public function testCreateObjectifiesEmptyInitialDataSourceProperties(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('initial_data_source', $body);
+            $this->assertSame([], $body['initial_data_source']['properties']);
+            $this->assertStringContainsString('"properties":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"properties":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_databases_create_database_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2025_09_03)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $database = new Database();
+        $database->setParent((new PageIdParent())->setPageId('4a808e6e88454d49a447fb2a4c460f6f'));
+        $database->setTitle([Text::fromContent('Tasks')]);
+
+        $client->databases()->create($database);
+    }
+
+    public function testCreateKeepsSelectOptionsAsArray(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame(
+                'Yes',
+                $body['initial_data_source']['properties']['in stock']['select']['options'][0]['name'],
+            );
+            $this->assertStringNotContainsString('"options":{}', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_databases_create_database_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $options = (new ClientOptions())
+            ->setNotionVersion(ClientOptions::NOTION_VERSION_2025_09_03)
+            ->setHttpClient($httpClient);
+
+        $client = new Client($options);
+
+        $selectObject = new SelectPropertyObject();
+        $selectObject->setSelect(
+            (new SelectPropertyConfiguration())->setOptions([
+                (new SelectProperty())->setName('Yes')->setColor('green'),
+            ]),
+        );
+
+        $database = new Database();
+        $database->setParent((new PageIdParent())->setPageId('4a808e6e88454d49a447fb2a4c460f6f'));
+        $database->setTitle([Text::fromContent('Tasks')]);
+        $database->setProperties([
+            'name' => new TitlePropertyObject(),
+            'in stock' => $selectObject,
+        ]);
+
+        $client->databases()->create($database);
     }
 }


### PR DESCRIPTION
## Description

Extends the empty-config normalization (#97/#99) one level deeper so relation properties with nested empty objects serialize as objects rather than arrays:

- `normalizeEmptyPropertyConfigurations()` previously objectified only a property's top-level empty config (`"title": []` → `{}`). It never descended into a non-empty config, so a relation whose nested config is empty — `"relation": {"data_source_id": "…", "type": "single_property", "single_property": []}` — serialized `single_property` as `[]`, which the API rejects (`body failed validation: … should be an object, instead was []`). It now objectifies known object-valued nested keys (`single_property` and `dual_property` under `relation`) while leaving list-valued keys (`options` on select/multi_select/status, `groups` on status) untouched.
- `RelationPropertyConfiguration` now models the relation `type` and the `single_property` / `dual_property` markers, with `setSinglePropertyRelation()` / `setDualPropertyRelation()` helpers, and preserves them on `fromRawData()` round-trips. Previously the SDK could not express a single- or dual-property relation at all, forcing consumers to bypass the endpoints with raw request bodies.
- `DatabasesEndpoint::create()` sent `initial_data_source.properties: []` when no properties were provided; the API rejects that too (`should be an object or `undefined``). It is now serialized as `{}`.

## Motivation and context

Programmatic schema creation with relation columns — the common case for setting up a linked database — failed on both `databases()->create()` (via `initial_data_source`) and `dataSources()->update()`. There was no way to build a single- or dual-property relation through the typed endpoints, so consumers had to fall back to raw payloads.

## How has this been tested?

- New unit tests assert on the raw serialized JSON: `databases()->create()` with a `single_property` relation in `initial_data_source`, `dataSources()->update()` with hydrated `single_property` and `dual_property` relations, and `databases()->create()` with no properties serializing `initial_data_source.properties` as `{}`. Regression tests assert `select` `options` stays an array (`[]`, never `{}`).
- Empirically confirmed against the API that `initial_data_source.properties: []` is rejected while `{}` is accepted, which is why the empty-properties case is normalized.
- Verified live against the Notion API: through the endpoints, created a database whose initial data source carries a `single_property` relation, then updated the data source to add a `dual_property` relation and a second `single_property` relation; all three were read back with their relation types intact. Scratch objects were cleaned up.
- Full suite green (227 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
