### PR TITLE
fix(data-sources): accept raw property configurations on update

### DIFF
--- a/src/Resource/DataSource.php
+++ b/src/Resource/DataSource.php
@@ -18,7 +18,11 @@ use Brd6\NotionSdkPhp\Resource\RichText\AbstractRichText;
 use Brd6\NotionSdkPhp\Resource\User\AbstractUser;
 use DateTimeImmutable;
 
+use function array_diff;
+use function array_keys;
 use function array_map;
+use function array_values;
+use function count;
 use function in_array;
 use function is_array;
 
@@ -228,13 +232,49 @@ class DataSource extends AbstractResource
     }
 
     /**
-     * @param array<string, AbstractPropertyObject> $properties
+     * @param array<string, AbstractPropertyObject|array> $properties
+     *
+     * @throws InvalidPropertyObjectException
+     * @throws UnsupportedPropertyObjectException
      */
     public function setProperties(array $properties): self
     {
-        $this->properties = $properties;
+        $this->properties = array_map(
+            fn ($property) => self::hydrateProperty($property),
+            $properties,
+        );
 
         return $this;
+    }
+
+    /**
+     * @param AbstractPropertyObject|array $property
+     *
+     * @throws InvalidPropertyObjectException
+     * @throws UnsupportedPropertyObjectException
+     */
+    private static function hydrateProperty($property): AbstractPropertyObject
+    {
+        if ($property instanceof AbstractPropertyObject) {
+            return $property;
+        }
+
+        return AbstractPropertyObject::fromRawData(self::withResolvedPropertyType($property));
+    }
+
+    private static function withResolvedPropertyType(array $property): array
+    {
+        if (isset($property['type'])) {
+            return $property;
+        }
+
+        $configKeys = array_diff(array_keys($property), ['id', 'name']);
+
+        if (count($configKeys) === 1) {
+            $property['type'] = array_values($configKeys)[0];
+        }
+
+        return $property;
     }
 
     public function getParent(): ?AbstractParentProperty

--- a/tests/Endpoint/DataSourcesEndpointTest.php
+++ b/tests/Endpoint/DataSourcesEndpointTest.php
@@ -355,4 +355,147 @@ class DataSourcesEndpointTest extends TestCase
 
         $client->dataSources()->update($dataSource);
     }
+
+    public function testUpdateAcceptsRawSinglePropertyRelationConfiguration(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['properties']['Project']['relation'];
+            $this->assertSame('single_property', $relation['type']);
+            $this->assertSame([], $relation['single_property']);
+            $this->assertSame('target-ds', $relation['data_source_id']);
+            $this->assertStringContainsString('"single_property":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"single_property":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $dataSource = (new DataSource())
+            ->setId('164b19c5-58e5-4a47-a3a9-c905d9519c65')
+            ->setProperties([
+                'Project' => [
+                    'type' => 'relation',
+                    'relation' => [
+                        'data_source_id' => 'target-ds',
+                        'type' => 'single_property',
+                        'single_property' => [],
+                    ],
+                ],
+            ]);
+
+        $client->dataSources()->update($dataSource);
+    }
+
+    public function testUpdateAcceptsRawDualPropertyRelationConfiguration(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $relation = $body['properties']['Project']['relation'];
+            $this->assertSame('dual_property', $relation['type']);
+            $this->assertSame([], $relation['dual_property']);
+            $this->assertStringContainsString('"dual_property":{}', (string) $options['body']);
+            $this->assertStringNotContainsString('"dual_property":[]', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $dataSource = (new DataSource())
+            ->setId('164b19c5-58e5-4a47-a3a9-c905d9519c65')
+            ->setProperties([
+                'Project' => [
+                    'type' => 'relation',
+                    'relation' => [
+                        'data_source_id' => 'target-ds',
+                        'type' => 'dual_property',
+                        'dual_property' => [],
+                    ],
+                ],
+            ]);
+
+        $client->dataSources()->update($dataSource);
+    }
+
+    public function testUpdateAcceptsRawSelectConfigurationKeepingOptionsAsArray(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $select = $body['properties']['Status']['select'];
+            $this->assertSame('Todo', $select['options'][0]['name']);
+            $this->assertStringNotContainsString('"options":{}', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $dataSource = (new DataSource())
+            ->setId('164b19c5-58e5-4a47-a3a9-c905d9519c65')
+            ->setProperties([
+                'Status' => [
+                    'type' => 'select',
+                    'select' => [
+                        'options' => [
+                            ['name' => 'Todo', 'color' => 'red'],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $client->dataSources()->update($dataSource);
+    }
+
+    public function testUpdateAcceptsMixedRawAndTypedPropertyConfigurations(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            /** @var array $body */
+            $body = json_decode($options['body'], true);
+
+            $this->assertArrayHasKey('Name', $body['properties']);
+            $this->assertStringContainsString('"title":{}', (string) $options['body']);
+            $this->assertSame('single_property', $body['properties']['Project']['relation']['type']);
+            $this->assertStringContainsString('"single_property":{}', (string) $options['body']);
+
+            return new MockResponseFactory(
+                (string) file_get_contents('tests/Fixtures/client_data_sources_retrieve_200.json'),
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new Client((new ClientOptions())->setHttpClient($httpClient));
+
+        $dataSource = (new DataSource())
+            ->setId('164b19c5-58e5-4a47-a3a9-c905d9519c65')
+            ->setProperties([
+                'Name' => new TitlePropertyObject(),
+                'Project' => [
+                    'type' => 'relation',
+                    'relation' => [
+                        'data_source_id' => 'target-ds',
+                        'type' => 'single_property',
+                        'single_property' => [],
+                    ],
+                ],
+            ]);
+
+        $client->dataSources()->update($dataSource);
+    }
 }

--- a/tests/Resource/DataSourceTest.php
+++ b/tests/Resource/DataSourceTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Brd6\Test\NotionSdkPhp\Resource;
 
+use Brd6\NotionSdkPhp\Exception\InvalidPropertyObjectException;
 use Brd6\NotionSdkPhp\Exception\InvalidResourceException;
+use Brd6\NotionSdkPhp\Exception\UnsupportedPropertyObjectException;
 use Brd6\NotionSdkPhp\Resource\DataSource;
 use Brd6\NotionSdkPhp\Resource\Database\PropertyObject\RelationPropertyObject;
 use Brd6\NotionSdkPhp\Resource\File\Icon;
@@ -43,6 +45,65 @@ class DataSourceTest extends TestCase
         $this->assertArrayHasKey('Projects', $properties);
         $this->assertArrayNotHasKey('Created time', $properties);
         $this->assertArrayNotHasKey('Last edited by', $properties);
+    }
+
+    public function testUpdateSerializationIsByteIdenticalForTypedAndRawProperties(): void
+    {
+        $rawConfig = [
+            'type' => 'relation',
+            'relation' => [
+                'data_source_id' => 'target-ds',
+                'type' => 'single_property',
+                'single_property' => [],
+            ],
+        ];
+
+        $typed = (new DataSource())
+            ->setId('ds')
+            ->setProperties([
+                'Project' => RelationPropertyObject::fromRawData($rawConfig),
+            ]);
+
+        $raw = (new DataSource())
+            ->setId('ds')
+            ->setProperties(['Project' => $rawConfig]);
+
+        $this->assertSame($typed->toArrayForUpdate(), $raw->toArrayForUpdate());
+    }
+
+    public function testUpdateFiltersReadOnlyConfigurationsSetAsRawArrays(): void
+    {
+        $dataSource = (new DataSource())
+            ->setId('ds')
+            ->setProperties([
+                'Name' => ['type' => 'title', 'title' => []],
+                'Created time' => ['type' => 'created_time', 'created_time' => []],
+                'Last edited by' => ['type' => 'last_edited_by', 'last_edited_by' => []],
+            ]);
+
+        $properties = $dataSource->toArrayForUpdate()['properties'];
+
+        $this->assertArrayHasKey('Name', $properties);
+        $this->assertArrayNotHasKey('Created time', $properties);
+        $this->assertArrayNotHasKey('Last edited by', $properties);
+    }
+
+    public function testSetPropertiesRejectsRawArrayWithUnresolvableType(): void
+    {
+        $this->expectException(InvalidPropertyObjectException::class);
+
+        (new DataSource())->setProperties([
+            'Ambiguous' => ['id' => 'x', 'name' => 'Ambiguous'],
+        ]);
+    }
+
+    public function testSetPropertiesRejectsRawArrayWithUnknownType(): void
+    {
+        $this->expectException(UnsupportedPropertyObjectException::class);
+
+        (new DataSource())->setProperties([
+            'Mystery' => ['type' => 'not_a_real_type', 'not_a_real_type' => []],
+        ]);
     }
 
     public function testDataSourceHydratesInTrashPayloadWithoutArchivedKey(): void


### PR DESCRIPTION
## Description

Makes the data-source update path accept raw property-configuration arrays, matching what the create path already accepts:

- `DatabasesEndpoint::create()` tolerates raw property-configuration arrays (its `toArray()` + `normalizeEmptyPropertyConfigurations()` path), but `DataSource::toArrayForUpdate()` iterated `$this->properties` calling `->getType()` on each entry, so a data source whose properties were set as raw arrays through `setProperties()` fatal-errored (`Call to a member function getType() on array`). Consumers doing programmatic schema updates were forced to hand-build typed `AbstractPropertyObject` instances (`setType`/`setName` included) — an asymmetry with the create path that leaked internal shape knowledge.
- `DataSource::setProperties()` now hydrates any raw array configuration into the matching typed property object via the existing `AbstractPropertyObject::fromRawData()` factory, while passing already-typed objects through unchanged. When a raw configuration omits an explicit `type`, it is resolved from the single non-metadata config key (the same resolution the create path uses). Mixed maps of typed objects and raw arrays work.
- `toArrayForUpdate()` is unchanged: every entry is now a typed object, so read-only computed-configuration filtering keeps working and the serialized output for already-typed objects is byte-identical.

## Motivation and context

Programmatic schema editing was inconsistent: the same raw configuration array accepted by `databases()->create()` threw a fatal error when passed to `dataSources()->update()`. Building a relation or select configuration for an update required constructing typed property objects by hand, which is more internal knowledge than the create path demands.

## How has this been tested?

- New unit tests: typed-vs-raw update serialization is byte-identical; read-only computed configurations set as raw arrays are still filtered out of the update payload.
- New endpoint tests asserting on the raw serialized JSON: raw `single_property` and `dual_property` relation configurations serialize their nested empties as `{}` (composing with the existing empty-config normalization); a raw `select` configuration keeps `options` as an array (never `{}`); a mixed typed + raw property map serializes correctly.
- Verified live against the Notion API: through `dataSources()->update()`, a data source was updated using only raw property-configuration arrays (a `single_property` relation, a `dual_property` relation, and a `select` with options); all were read back with their relation types and options intact. Scratch objects were cleaned up.
- The fix is scoped to `DataSource`; `Database::toArrayForUpdate()` does not iterate properties, so it never hit this path.
- Full suite green (234 tests), plus `parallel-lint`, `phpcs`, PHPStan, and Psalm.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
