### PR TITLE
fix(rich-text): serialize a text link as an object

### DIFF
--- a/src/Resource/Link.php
+++ b/src/Resource/Link.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Brd6\NotionSdkPhp\Resource;
 
-class Link
+class Link extends AbstractJsonSerializable
 {
     protected string $type = '';
     protected string $url = '';

--- a/tests/Resource/LinkTest.php
+++ b/tests/Resource/LinkTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brd6\Test\NotionSdkPhp\Resource;
+
+use Brd6\NotionSdkPhp\Resource\Block\ParagraphBlock;
+use Brd6\NotionSdkPhp\Resource\Link;
+use Brd6\NotionSdkPhp\Resource\Property\ParagraphProperty;
+use Brd6\NotionSdkPhp\Resource\Property\TextProperty;
+use Brd6\NotionSdkPhp\Resource\RichText\Text;
+use PHPUnit\Framework\TestCase;
+
+class LinkTest extends TestCase
+{
+    public function testItSerializesItsUrl(): void
+    {
+        $link = (new Link())->setUrl('https://example.test/a');
+
+        $this->assertSame(['url' => 'https://example.test/a'], $link->toArray());
+    }
+
+    public function testItOmitsTheEmptyTypeNotionDoesNotExpect(): void
+    {
+        $link = (new Link())->setUrl('https://example.test/a');
+
+        $this->assertArrayNotHasKey('type', $link->toArray());
+    }
+
+    /**
+     * The API rejects the whole request when `text.link` arrives as an empty array:
+     * "link should be an object, `null`, or `undefined`, instead was `[]`".
+     */
+    public function testALinkedTextSerializesAsAnObjectForCreate(): void
+    {
+        $text = Text::fromContent('Linked');
+        $text->getText()?->setLink((new Link())->setUrl('https://example.test/a'));
+
+        $block = (new ParagraphBlock())->setParagraph((new ParagraphProperty())->setRichText([$text]));
+
+        $data = $block->toArrayForCreate();
+
+        $this->assertSame(
+            ['url' => 'https://example.test/a'],
+            $data['paragraph']['rich_text'][0]['text']['link'],
+        );
+    }
+
+    public function testAnUnlinkedTextStillSerializesWithoutALink(): void
+    {
+        $block = (new ParagraphBlock())->setParagraph(
+            (new ParagraphProperty())->setRichText([Text::fromContent('Plain')]),
+        );
+
+        $data = $block->toArrayForCreate();
+
+        $this->assertArrayNotHasKey('link', $data['paragraph']['rich_text'][0]['text']);
+    }
+
+    public function testItKeepsRoundTrippingRawDataFromTheApi(): void
+    {
+        $property = TextProperty::fromRawData([
+            'content' => 'Linked',
+            'link' => ['url' => 'https://example.test/a'],
+        ]);
+
+        $this->assertSame('https://example.test/a', $property->getLink()?->getUrl());
+    }
+}

--- a/tests/Resource/LinkTest.php
+++ b/tests/Resource/LinkTest.php
@@ -34,7 +34,9 @@ class LinkTest extends TestCase
     public function testALinkedTextSerializesAsAnObjectForCreate(): void
     {
         $text = Text::fromContent('Linked');
-        $text->getText()?->setLink((new Link())->setUrl('https://example.test/a'));
+        $property = $text->getText();
+        $this->assertInstanceOf(TextProperty::class, $property);
+        $property->setLink((new Link())->setUrl('https://example.test/a'));
 
         $block = (new ParagraphBlock())->setParagraph((new ParagraphProperty())->setRichText([$text]));
 
@@ -64,6 +66,8 @@ class LinkTest extends TestCase
             'link' => ['url' => 'https://example.test/a'],
         ]);
 
-        $this->assertSame('https://example.test/a', $property->getLink()?->getUrl());
+        $link = $property->getLink();
+        $this->assertInstanceOf(Link::class, $link);
+        $this->assertSame('https://example.test/a', $link->getUrl());
     }
 }


### PR DESCRIPTION
## Description

`Link` did not extend `AbstractJsonSerializable`, so its `protected` properties were invisible to `json_encode`. Every other property resource in the library extends that base class; `Link` was the exception.

The consequence is that a rich text carrying a link serialized as `"link": []` instead of `"link": {"url": "..."}`.

```php
$text = Text::fromContent('Linked');
$text->getText()?->setLink((new Link())->setUrl('https://example.test/a'));

$block = (new ParagraphBlock())->setParagraph(
    (new ParagraphProperty())->setRichText([$text]),
);

$block->toArrayForCreate();
// text.link => []   (before)
// text.link => ['url' => 'https://example.test/a']   (after)
```

This one-line change makes `Link` extend `AbstractJsonSerializable`, which is all that is needed for the existing `toArray()` machinery to serialize it. Reading is unaffected: `Link::fromRawData()` already worked, and a round-trip test covers it.

## Motivation and context

The empty array is rejected by the Notion API, so creating a block with a linked rich text fails outright:

```
body failed validation: body.children[0].paragraph.rich_text[0].text.link
should be an object, `null`, or `undefined`, instead was `[]`.
```

Setting the rich text's `href` instead looks like a viable workaround, but it is not: the API accepts `href` on create, returns `200`, and then silently discards it. The text arrives unlinked and merged into its adjacent runs, so callers get a success response and no link. Serializing `text.link` as an object is the only shape that produces a hyperlink.

## How has this been tested?

- Added `tests/Resource/LinkTest.php` covering the serialized shape, the omitted empty `type`, a linked rich text inside `toArrayForCreate()`, an unlinked rich text (no `link` key), and a `fromRawData()` round-trip.
- Full suite: 241 tests, 1234 assertions, all passing on PHP 8.4.
- `phpcs` and `phpstan` clean.
- Verified against the live Notion API: appending a callout whose CTA carries `text.link.url` returns `200` and the created block comes back with the rich-text runs kept separate and `href` populated on the linked run. The same payload built with `href` alone comes back with `href: null` and the runs merged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
